### PR TITLE
Configuration Final Touches

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 VOLUME_PATH=data
+LOG_LEVEL=debug
 
 # Dune credentials
 DUNE_API_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -5,12 +5,13 @@ LOG_LEVEL=debug
 DUNE_API_KEY=
 
 # AWS Credentials
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
 AWS_INTERNAL_ROLE=
 AWS_EXTERNAL_ROLE=
 AWS_EXTERNAL_ID=
 AWS_BUCKET=
-## This one is a bit weird... refers to a file at ~./aws/profile
-AWS_PROFILE=
 
 #Orderbook DB Credentials
 BARN_DB_URL={user}:{password}@{host}:{port}/{database}

--- a/src/environment.py
+++ b/src/environment.py
@@ -1,5 +1,22 @@
 """Project Global Constants."""
+import argparse
+import logging
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent
 QUERY_PATH = PROJECT_ROOT / Path("src/sql")
+
+
+def parse_log_level() -> str:
+    """Parses Global Log Level from runtime arguments (default = INFO)"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-l", "--log-level", type=str, default="INFO", help="set log level"
+    )
+    args, _ = parser.parse_known_args()
+    level: str = args.log_level.upper()
+    logging.info(f"Global Log Level configured as {level}")
+    return level
+
+
+LOG_LEVEL = parse_log_level()

--- a/src/logger.py
+++ b/src/logger.py
@@ -9,7 +9,7 @@ from src.environment import LOG_LEVEL
 def set_log(name: str) -> Logger:
     """
     Instantiates and returns a logger with the name defined by the caller.
-    Used by any file which wants to inherit the global log level configuration 
+    Used by any file which wants to inherit the global log level configuration
     and assigns the desired naming convention (usually `__name__`)
     """
 

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,0 +1,19 @@
+"""Easy universal log configuration """
+import logging.config
+import sys
+from logging import Logger
+
+from src.environment import LOG_LEVEL
+
+
+def set_log(name: str) -> Logger:
+    """Removes redundancy when setting log in each file"""
+
+    log = logging.getLogger(name)
+    try:
+        log.setLevel(level=LOG_LEVEL)
+    except ValueError:
+        logging.error(f"Invalid log level: {LOG_LEVEL}")
+        sys.exit(1)
+
+    return log

--- a/src/logger.py
+++ b/src/logger.py
@@ -7,7 +7,11 @@ from src.environment import LOG_LEVEL
 
 
 def set_log(name: str) -> Logger:
-    """Removes redundancy when setting log in each file"""
+    """
+    Instantiates and returns a logger with the name defined by the caller.
+    Used by any file which wants to inherit the global log level configuration 
+    and assigns the desired naming convention (usually `__name__`)
+    """
 
     log = logging.getLogger(name)
     try:

--- a/src/main.py
+++ b/src/main.py
@@ -51,7 +51,7 @@ class ScriptArgs:
             help="Flag indicating whether script should not post files to AWS or not",
             default=False,
         )
-        arguments = parser.parse_args()
+        arguments, _ = parser.parse_known_args()
         self.sync_table: SyncTable = arguments.sync_table
         self.dry_run: bool = arguments.dry_run
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,10 +9,9 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from src.environment import PROJECT_ROOT
+from src.fetch.dune import DuneFetcher
 from src.fetch.orderbook import OrderbookFetcher
 from src.sync import sync_app_data
-from src.fetch.dune import DuneFetcher
 from src.sync.config import SyncConfig, AWSData
 from src.sync.order_rewards import sync_order_rewards
 
@@ -65,10 +64,9 @@ if __name__ == "__main__":
         external_id=os.environ["AWS_EXTERNAL_ID"],
         bucket=os.environ["AWS_BUCKET"],
     )
-    volume_path = PROJECT_ROOT / Path(os.environ.get("VOLUME_PATH", "data"))
+    volume_path = Path(os.environ["VOLUME_PATH"])
 
     args = ScriptArgs()
-    # TODO - pass dry-run into runners!
     if args.sync_table == SyncTable.APP_DATA:
         asyncio.run(
             sync_app_data(

--- a/src/post/aws.py
+++ b/src/post/aws.py
@@ -1,10 +1,13 @@
 """Aws S3 Bucket functionality (namely upload_file)"""
-import logging
 
 import boto3
 from boto3.resources.base import ServiceResource
 from boto3.s3.transfer import S3Transfer
 from botocore.client import BaseClient
+
+from src.logger import set_log
+
+log = set_log(__name__)
 
 
 class AWSClient:
@@ -16,7 +19,6 @@ class AWSClient:
         self.internal_role = internal_role
         self.external_role = external_role
         self.external_id = external_id
-
         self.service_resource = self._assume_role()
         self.s3_client = self._get_s3_client(self.service_resource)
 
@@ -74,7 +76,7 @@ class AWSClient:
             key=object_key,
             extra_args={"ACL": "bucket-owner-full-control"},
         )
-        logging.info(f"successfully uploaded {filename} to {bucket}")
+        log.debug(f"uploaded {filename} to {bucket}")
         return True
 
     def delete_file(self, bucket: str, object_key: str) -> bool:
@@ -90,7 +92,7 @@ class AWSClient:
             Bucket=bucket,
             Key=object_key,
         )
-        logging.info(f"successfully deleted {object_key} from {bucket}")
+        log.debug(f"deleted {object_key} from {bucket}")
         return True
 
     def download_file(self, filename: str, bucket: str, object_key: str) -> bool:
@@ -107,5 +109,5 @@ class AWSClient:
             bucket=bucket,
             key=object_key,
         )
-        logging.info(f"successfully downloaded {filename} from {bucket}")
+        log.debug(f"downloaded {filename} from {bucket}")
         return True

--- a/src/sync/app_data.py
+++ b/src/sync/app_data.py
@@ -1,20 +1,18 @@
 """Main Entry point for app_hash sync"""
 import json
-import logging.config
 
 from dune_client.file.interface import FileIO
 from dune_client.types import DuneRecord
 
 from src.fetch.dune import DuneFetcher
 from src.fetch.ipfs import Cid
+from src.logger import set_log
 from src.models.block_range import BlockRange
 from src.post.aws import AWSClient
 from src.sync.common import last_sync_block, aws_login_and_upload
 from src.sync.config import SyncConfig
 
-log = logging.getLogger(__name__)
-logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s")
-log.setLevel(logging.DEBUG)
+log = set_log(__name__)
 
 
 MAX_RETRIES = 3

--- a/src/sync/common.py
+++ b/src/sync/common.py
@@ -7,10 +7,11 @@ from pathlib import Path
 from dune_client.file.interface import FileIO
 from s3transfer import S3UploadFailedError
 
+from src.logger import set_log
 from src.post.aws import AWSClient
 from src.sync.config import SyncConfig
 
-log = logging.getLogger(__name__)
+log = set_log(__name__)
 
 
 def last_sync_block(

--- a/src/sync/order_rewards.py
+++ b/src/sync/order_rewards.py
@@ -1,19 +1,17 @@
 """Main Entry point for app_hash sync"""
 import csv
-import logging.config
 import os.path
 
 from dune_client.file.interface import FileIO
 from pandas import DataFrame
 
 from src.fetch.orderbook import OrderbookFetcher
+from src.logger import set_log
 from src.models.block_range import BlockRange
 from src.sync.common import last_sync_block, aws_login_and_upload
 from src.sync.config import SyncConfig
 
-log = logging.getLogger(__name__)
-logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s")
-log.setLevel(logging.DEBUG)
+log = set_log(__name__)
 
 
 class RecordHandler:  # pylint:disable=too-few-public-methods


### PR DESCRIPTION
Preparing for deployment on kubernetes we fix a few things:

- using an absolute VOLUME_PATH (instead of relative to the project root)
- configure log level via runtime arguments
- use AWS access keys instead of PROFILE (so we don't have to rely on a credentials existing within the file system).


## Test Plan

Integration tests (however they all require A LOT of credentials). You could run the main branch in `dry-run` mode with empty aws credentials (however, there was a subtle bug discovered here while testing that is resolved in a follow up PR #10). 

```sh
python -m src.main --sync-table order_rewards --dry-run True
python -m src.main --sync-table app_data --dry-run True  <--! Running This from scratch takes over an hour!
```