### PR TITLE
[order_rewards] Add surplus fee

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,28 @@ You will need to attach a volume and have an env file configuration. This exampl
 ```shell
 docker run -v ${PWD}/data:/app/data --env-file .env ghcr.io/cowprotocol/dune-sync:latest
 ```
+
+
+### Breaking Changes
+
+Whenever the schema changes, we must coordinate with Dune that the data must be dropped and the table rebuilt.
+For this we have implemented a feature flag `--hard-reset True` which can be called to delete all data from their 
+buckets and our backup volume. This should only be run whilst in coordination with their team about the changes. 
+They will "stop the stream", drop the table on their side and restart the stream. 
+In the event that a hard reset is performed without the proper coordination, 
+it is likely that duplicate records will appear in their production environment (i.e. the interface). 
+
+So, the process is:
+
+- Contact a Dune Team Member (@dsalv)
+- Mention that we need to rebuild table XYZ (because of a schema change)
+- Once they are aware/prepared run
+```shell
+docker run -v ${PWD}/data:/app/data \
+    --env-file .env \
+    ghcr.io/cowprotocol/dune-sync \
+    --sync-table SYNC_TABLE \
+    --hard-reset True
+```
+
+This will empty the buckets and repopulate with the appropriate changes.

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -10,7 +10,6 @@ from dotenv import load_dotenv
 from pandas import DataFrame
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import ProgrammingError
 
 from src.models.block_range import BlockRange
 from src.utils import open_query
@@ -45,21 +44,10 @@ class OrderbookFetcher:
         db_string = f"postgresql+psycopg2://{db_url}"
         return create_engine(db_string)
 
-    @staticmethod
-    def _exec_query(query: str, engine: Engine) -> DataFrame:
-        try:
-            return pd.read_sql(
-                sql=query.replace("{{reward_table}}", "order_execution"), con=engine
-            )
-        except ProgrammingError:
-            return pd.read_sql(
-                sql=query.replace("{{reward_table}}", "order_rewards"), con=engine
-            )
-
     @classmethod
     def _query_both_dbs(cls, query: str) -> tuple[DataFrame, DataFrame]:
-        barn = cls._exec_query(query, engine=cls._pg_engine(OrderbookEnv.BARN))
-        prod = cls._exec_query(query, engine=cls._pg_engine(OrderbookEnv.PROD))
+        barn = pd.read_sql(query, con=cls._pg_engine(OrderbookEnv.BARN))
+        prod = pd.read_sql(query, con=cls._pg_engine(OrderbookEnv.PROD))
         return barn, prod
 
     @classmethod

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import argparse
 import asyncio
 import logging.config
 import os
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -26,6 +27,7 @@ class ScriptArgs:
     """Runtime arguments' parser/initializer"""
 
     dry_run: bool
+    hard_reset: bool
     sync_table: SyncTable
 
     def __init__(self) -> None:
@@ -42,9 +44,17 @@ class ScriptArgs:
             help="Flag indicating whether script should not post files to AWS or not",
             default=False,
         )
+        parser.add_argument(
+            "--hard-reset",
+            type=bool,
+            help="Flag indicating whether the existing sync table data should "
+                 "be deleted from the bucket and rebuilt from scratch",
+            default=False,
+        )
         arguments, _ = parser.parse_known_args()
         self.sync_table: SyncTable = arguments.sync_table
         self.dry_run: bool = arguments.dry_run
+        self.hard_reset: bool = arguments.hard_reset
 
 
 if __name__ == "__main__":
@@ -52,6 +62,12 @@ if __name__ == "__main__":
     volume_path = Path(os.environ["VOLUME_PATH"])
     args = ScriptArgs()
     aws = AWSClient.new_from_environment()
+    if args.hard_reset and not args.dry_run:
+        # Drop Data from AWS bucket
+        aws.delete_all(args.sync_table)
+        # drop backup data from volume path
+        shutil.rmtree(volume_path / str(args.sync_table))
+
     if args.sync_table == SyncTable.APP_DATA:
         asyncio.run(
             sync_app_data(

--- a/src/main.py
+++ b/src/main.py
@@ -48,7 +48,7 @@ class ScriptArgs:
             "--hard-reset",
             type=bool,
             help="Flag indicating whether the existing sync table data should "
-                 "be deleted from the bucket and rebuilt from scratch",
+            "be deleted from the bucket and rebuilt from scratch",
             default=False,
         )
         arguments, _ = parser.parse_known_args()

--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -23,6 +23,7 @@ with trade_hashes as (SELECT solver,
 select concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
        concat('0x', encode(solver, 'hex'))  as solver,
        concat('0x', encode(tx_hash, 'hex')) as tx_hash,
+       surplus_fee::text,
        coalesce(reward, 0.0)                as amount,
        -- An order is a liquidity order if and only if reward is null.
        -- A liquidity order is safe if and only if its fee_amount is > 0
@@ -31,6 +32,6 @@ select concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
            when reward is null and fee_amount = 0 then False
            end                              as safe_liquidity
 from trade_hashes
-         left outer join {{reward_table}} o
+         left outer join order_execution o
                          on trade_hashes.order_uid = o.order_uid
                              and trade_hashes.auction_id = o.auction_id;

--- a/tests/integration/test_fetch_orderbook.py
+++ b/tests/integration/test_fetch_orderbook.py
@@ -33,6 +33,7 @@ class MyTestCase(unittest.TestCase):
                     "0xb6f7df8a1114129f7b61f2863b3f81b3620e95f73e5b769a62bb7a87ab6983f4",
                     "0x2ce77009e78c291cdf39eb6f8ddf7e2c3401b4f962ef1240bdac47e632f8eb7f",
                 ],
+                "surplus_fee": [None, None],
                 "amount": [40.70410, 39.00522],
                 "safe_liquidity": [None, None],
             }


### PR DESCRIPTION
1. This PR changes the schema of the order rewards table and requires coordination with the Dune team to update it on their end. Since the values are in WEI, to preserve accuracy we extract and store as string type.

2. This PR also introduces a breaking change feature for "hard reset" which empties the AWS buckets and removes the same data from our local storage, before proceeding with the sync script.

This is one part of a bigger change to make limit order fees available in Dune Community sources (so that the slippage query can consume it for solver-rewards).

cc @nlordell 

Tagging also @dsalv (since I have included your github handle in the README and wanted to make sure this is OK with you).

It is nice that we haven't already released this to production (because these kinds of changes should NOT be regular occurrences)