### PR TITLE
[Schema] Order Rewards to use JSON field for variable data.

### DIFF
--- a/src/models/order_rewards_schema.py
+++ b/src/models/order_rewards_schema.py
@@ -1,0 +1,69 @@
+"""Model for Order Rewards Data"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pandas import DataFrame
+
+
+@dataclass
+class OrderRewards:
+    """
+    This class provides a transformation interface for the Dataframe we fetch from the orderbook
+    Within are several methods for converting from the Dataframe to list[DuneRecords]
+    """
+
+    order_uid: str
+    tx_hash: str
+    solver: str
+    data: dict[str, Any]
+
+    @classmethod
+    def from_pdf(cls, rewards_df: DataFrame) -> list[OrderRewards]:
+        """Multi Record Constructor from Pandas Dataframe"""
+        return [
+            cls(
+                order_uid=row["order_uid"],
+                tx_hash=row["tx_hash"],
+                solver=row["solver"],
+                data={
+                    # This seems like a hack. I need to experiment with Decimal type
+                    # CAST("18446744073709001111111111" AS DECIMAL(38,0));
+                    # but this can be done on the spellbook side.
+                    "surplus_fee": str(row["surplus_fee"]),
+                    "amount": float(row["amount"]),
+                    "safe_liquidity": row["safe_liquidity"],
+                },
+            )
+            for row in rewards_df.to_dict(orient="records")
+        ]
+
+    def as_dune_record(self) -> dict[str, Any]:
+        """Convert to Dune Record"""
+        return {
+            "order_uid": self.order_uid,
+            "tx_hash": self.tx_hash,
+            "solver": self.solver,
+            "data": self.data,
+        }
+
+    @classmethod
+    def from_pdf_to_dune_records(cls, rewards_df: DataFrame) -> list[dict[str, Any]]:
+        """
+        The above two methods require two iterations of the entire record set
+        while this one combines both and requires only one.
+        """
+        return [
+            {
+                "order_uid": row["order_uid"],
+                "tx_hash": row["tx_hash"],
+                "solver": row["solver"],
+                "data": {
+                    "surplus_fee": str(row["surplus_fee"]),
+                    "amount": float(row["amount"]),
+                    "safe_liquidity": row["safe_liquidity"],
+                },
+            }
+            for row in rewards_df.to_dict(orient="records")
+        ]

--- a/src/models/order_rewards_schema.py
+++ b/src/models/order_rewards_schema.py
@@ -12,6 +12,7 @@ class OrderRewards:
     """
     This class provides a transformation interface for the Dataframe we fetch from the orderbook
     """
+
     @classmethod
     def from_pdf_to_dune_records(cls, rewards_df: DataFrame) -> list[dict[str, Any]]:
         """Converts Pandas DataFrame into the expected stream type for Dune"""

--- a/src/models/order_rewards_schema.py
+++ b/src/models/order_rewards_schema.py
@@ -11,40 +11,7 @@ from pandas import DataFrame
 class OrderRewards:
     """
     This class provides a transformation interface for the Dataframe we fetch from the orderbook
-    Within are several methods for converting from the Dataframe to list[DuneRecords]
     """
-
-    order_uid: str
-    tx_hash: str
-    solver: str
-    data: dict[str, Any]
-
-    @classmethod
-    def from_pdf(cls, rewards_df: DataFrame) -> list[OrderRewards]:
-        """Multi Record Constructor from Pandas Dataframe"""
-        return [
-            cls(
-                order_uid=row["order_uid"],
-                tx_hash=row["tx_hash"],
-                solver=row["solver"],
-                data={
-                    "surplus_fee": str(row["surplus_fee"]),
-                    "amount": float(row["amount"]),
-                    "safe_liquidity": row["safe_liquidity"],
-                },
-            )
-            for row in rewards_df.to_dict(orient="records")
-        ]
-
-    def as_dune_record(self) -> dict[str, Any]:
-        """Convert to Dune Record"""
-        return {
-            "order_uid": self.order_uid,
-            "tx_hash": self.tx_hash,
-            "solver": self.solver,
-            "data": self.data,
-        }
-
     @classmethod
     def from_pdf_to_dune_records(cls, rewards_df: DataFrame) -> list[dict[str, Any]]:
         """Converts Pandas DataFrame into the expected stream type for Dune"""

--- a/src/models/order_rewards_schema.py
+++ b/src/models/order_rewards_schema.py
@@ -28,9 +28,6 @@ class OrderRewards:
                 tx_hash=row["tx_hash"],
                 solver=row["solver"],
                 data={
-                    # This seems like a hack. I need to experiment with Decimal type
-                    # CAST("18446744073709001111111111" AS DECIMAL(38,0));
-                    # but this can be done on the spellbook side.
                     "surplus_fee": str(row["surplus_fee"]),
                     "amount": float(row["amount"]),
                     "safe_liquidity": row["safe_liquidity"],

--- a/src/models/order_rewards_schema.py
+++ b/src/models/order_rewards_schema.py
@@ -47,10 +47,7 @@ class OrderRewards:
 
     @classmethod
     def from_pdf_to_dune_records(cls, rewards_df: DataFrame) -> list[dict[str, Any]]:
-        """
-        The above two methods require two iterations of the entire record set
-        while this one combines both and requires only one.
-        """
+        """Converts Pandas DataFrame into the expected stream type for Dune"""
         return [
             {
                 "order_uid": row["order_uid"],

--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -23,7 +23,7 @@ with trade_hashes as (SELECT solver,
 select concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
        concat('0x', encode(solver, 'hex'))  as solver,
        concat('0x', encode(tx_hash, 'hex')) as tx_hash,
-       surplus_fee::text,
+       coalesce(surplus_fee, 0)::text       as surplus_fee,
        coalesce(reward, 0.0)                as amount,
        -- An order is a liquidity order if and only if reward is null.
        -- A liquidity order is safe if and only if its fee_amount is > 0

--- a/tests/integration/test_fetch_orderbook.py
+++ b/tests/integration/test_fetch_orderbook.py
@@ -33,7 +33,7 @@ class MyTestCase(unittest.TestCase):
                     "0xb6f7df8a1114129f7b61f2863b3f81b3620e95f73e5b769a62bb7a87ab6983f4",
                     "0x2ce77009e78c291cdf39eb6f8ddf7e2c3401b4f962ef1240bdac47e632f8eb7f",
                 ],
-                "surplus_fee": [None, None],
+                "surplus_fee": ["0", "0"],
                 "amount": [40.70410, 39.00522],
                 "safe_liquidity": [None, None],
             }

--- a/tests/integration/test_fetch_orderbook.py
+++ b/tests/integration/test_fetch_orderbook.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 
 import pandas as pd

--- a/tests/unit/test_order_rewards_schema.py
+++ b/tests/unit/test_order_rewards_schema.py
@@ -1,0 +1,59 @@
+import unittest
+
+import pandas as pd
+
+from src.models.order_rewards_schema import OrderRewards
+
+
+class TestModelOrderRewards(unittest.TestCase):
+    def test_order_rewards_transformation(self):
+        rewards_df = pd.DataFrame(
+            {
+                "order_uid": ["0x01", "0x02", "0x03"],
+                "solver": ["0x51", "0x52", "0x53"],
+                "tx_hash": ["0x71", "0x72", "0x73"],
+                "surplus_fee": [12345678910111213, 0, 0],
+                "amount": [40.70410, 39.00522, 0],
+                "safe_liquidity": [None, True, False],
+            }
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "order_uid": "0x01",
+                    "solver": "0x51",
+                    "tx_hash": "0x71",
+                    "data": {
+                        "surplus_fee": "12345678910111213",
+                        "amount": 40.70410,
+                        "safe_liquidity": None,
+                    },
+                },
+                {
+                    "order_uid": "0x02",
+                    "solver": "0x52",
+                    "tx_hash": "0x72",
+                    "data": {
+                        "surplus_fee": "0",
+                        "amount": 39.00522,
+                        "safe_liquidity": True,
+                    },
+                },
+                {
+                    "order_uid": "0x03",
+                    "solver": "0x53",
+                    "tx_hash": "0x73",
+                    "data": {
+                        "surplus_fee": "0",
+                        "amount": 0.0,
+                        "safe_liquidity": False,
+                    },
+                },
+            ],
+            OrderRewards.from_pdf_to_dune_records(rewards_df),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The schema proposed here is `[order_uid: str | tx_hash: str | solver: str | data ]` where (currently) data takes the following form:
```
Data {
   surplus_fee: str (we can make make this nullable, or use zero in place of null)
   amount: float
   safe_liquidity: boolean (nullable)
}
```
Examples, of this are provided in the unit test.


### Additional Notes
1. Technically the `solver` column isn't necessary since it can be obtained from the `tx_hash`. Let me know if we think it should be removed.

2. I spoke with Dune today about string types in spark SQL and their answer was as I expected:

> We use decimal(38,0) or just strings for large integers in spark. DuneSQL will provide native support for large integers but it’s not directly available in spark sql

Note that, we will use strings for the `surplus_fee` and cast to Decimal in the spell that parses this content.

## Test Plan

with all the appropriate credentials you can run:

```
python -m src.main --sync-table order_rewards --dry-run True
```

Which will process orders and write locally.
A sample output with two rows would look like this:

```
{"order_uid": "0xa386250eda29e80d804b228908968865ab31fa8023abc5bbbf532ba965ecaa6f844eb02130e1849bf94e15ef08cdf070fbf1302b639270eb", "tx_hash": "0x2a6ccd340d7fa12d483851d0d7fa5ae6627ec852a2e3c638bec3deac1c1837be", "solver": "0x97ec0a17432d71a3234ef7173c6b48a2c0940896", "data": {"surplus_fee": "0", "amount": 40.21522326123023, "safe_liquidity": null}}
{"order_uid": "0xb0677cedb8279bfde76e6c15cc264b61386d2e2b4ddeb76d59cea0a635c59eb0b2515a7221b2654f9faae0e4ed1d0e49aa7b85dd63927116", "tx_hash": "0x7e482a5b04dc78d64a36588e90d549ecfb2d5d9f90d261848bbfc3269758cda5", "solver": "0xc9ec550bea1c64d779124b23a26292cc223327b6", "data": {"surplus_fee": "0", "amount": 38.97091536669401, "safe_liquidity": null}}
```