### PR TITLE
Remove Safe Liquidity

### DIFF
--- a/src/fetch/ipfs.py
+++ b/src/fetch/ipfs.py
@@ -97,6 +97,10 @@ class Cid:
                             break
                     except asyncio.TimeoutError:
                         attempts += 1
+                    except aiohttp.ContentTypeError as err:
+                        log.warning(f"failed to parse response {response} with {err}")
+                        attempts += 1
+
 
                 if not content:
                     total_attempts = previous_attempts + max_retries

--- a/src/fetch/ipfs.py
+++ b/src/fetch/ipfs.py
@@ -61,7 +61,7 @@ class Cid:
         return None
 
     @classmethod
-    async def fetch_many(
+    async def fetch_many(  # pylint: disable=too-many-locals
         cls, missing_rows: list[dict[str, str]], max_retries: int = 3
     ) -> tuple[list[FoundContent], list[NotFoundContent]]:
         """Async AppData Fetching"""
@@ -100,7 +100,6 @@ class Cid:
                     except aiohttp.ContentTypeError as err:
                         log.warning(f"failed to parse response {response} with {err}")
                         attempts += 1
-
 
                 if not content:
                     total_attempts = previous_attempts + max_retries

--- a/src/models/order_rewards_schema.py
+++ b/src/models/order_rewards_schema.py
@@ -24,7 +24,6 @@ class OrderRewards:
                 "data": {
                     "surplus_fee": str(row["surplus_fee"]),
                     "amount": float(row["amount"]),
-                    "safe_liquidity": row["safe_liquidity"],
                 },
             }
             for row in rewards_df.to_dict(orient="records")

--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -24,13 +24,7 @@ select concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
        concat('0x', encode(solver, 'hex'))  as solver,
        concat('0x', encode(tx_hash, 'hex')) as tx_hash,
        coalesce(surplus_fee, 0)::text       as surplus_fee,
-       coalesce(reward, 0.0)                as amount,
-       -- An order is a liquidity order if and only if reward is null.
-       -- A liquidity order is safe if and only if its fee_amount is > 0
-       case
-           when reward is null and fee_amount > 0 then True
-           when reward is null and fee_amount = 0 then False
-           end                              as safe_liquidity
+       coalesce(reward, 0.0)                as amount
 from trade_hashes
          left outer join order_execution o
                          on trade_hashes.order_uid = o.order_uid

--- a/tests/integration/test_fetch_orderbook.py
+++ b/tests/integration/test_fetch_orderbook.py
@@ -34,7 +34,6 @@ class MyTestCase(unittest.TestCase):
                 ],
                 "surplus_fee": ["0", "0"],
                 "amount": [40.70410, 39.00522],
-                "safe_liquidity": [None, None],
             }
         )
 

--- a/tests/unit/test_order_rewards_schema.py
+++ b/tests/unit/test_order_rewards_schema.py
@@ -14,7 +14,6 @@ class TestModelOrderRewards(unittest.TestCase):
                 "tx_hash": ["0x71", "0x72", "0x73"],
                 "surplus_fee": [12345678910111213, 0, 0],
                 "amount": [40.70410, 39.00522, 0],
-                "safe_liquidity": [None, True, False],
             }
         )
 
@@ -27,7 +26,6 @@ class TestModelOrderRewards(unittest.TestCase):
                     "data": {
                         "surplus_fee": "12345678910111213",
                         "amount": 40.70410,
-                        "safe_liquidity": None,
                     },
                 },
                 {
@@ -37,7 +35,6 @@ class TestModelOrderRewards(unittest.TestCase):
                     "data": {
                         "surplus_fee": "0",
                         "amount": 39.00522,
-                        "safe_liquidity": True,
                     },
                 },
                 {
@@ -47,7 +44,6 @@ class TestModelOrderRewards(unittest.TestCase):
                     "data": {
                         "surplus_fee": "0",
                         "amount": 0.0,
-                        "safe_liquidity": False,
                     },
                 },
             ],


### PR DESCRIPTION
Related to https://github.com/cowprotocol/solver-rewards/pull/157 and this [slack discussion](https://cowservices.slack.com/archives/C036JAGRQ04/p1670575811093429?thread_ts=1670490472.953269&cid=C036JAGRQ04)

we remove safe liquidity field from query and order rewards schema.