### PR TITLE
Affiliate Data API

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -47,3 +47,4 @@ jobs:
         env:
           PROD_DB_URL: ${{ secrets.PROD_DB_URL }}
           BARN_DB_URL: ${{ secrets.BARN_DB_URL }}
+          DUNE_API_KEY: ${{ secrets.DUNE_API_KEY }}

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,4 @@
+Flask>=2.2.2
 dune-client>=0.3.0
 psycopg2-binary>=2.9.3
 python-dotenv>=0.20.0

--- a/src/api/affiliate.py
+++ b/src/api/affiliate.py
@@ -3,6 +3,7 @@ import os
 from typing import Any
 
 from dotenv import load_dotenv
+from dune_client.client import DuneClient
 from flask import Flask, jsonify
 
 from src.fetch.affiliate_data import CachingAffiliateFetcher
@@ -11,7 +12,7 @@ from src.logger import set_log
 app = Flask(__name__)
 load_dotenv()
 cached_fetcher = CachingAffiliateFetcher(
-    api_key=os.environ["DUNE_API_KEY"],
+    dune=DuneClient(os.environ["DUNE_API_KEY"]),
     execution_id=os.environ.get("LAST_EXECUTION_ID"),
     cache_validity=int(os.environ["CACHE_VALIDITY"]),
 )

--- a/src/api/affiliate.py
+++ b/src/api/affiliate.py
@@ -5,12 +5,12 @@ from typing import Any
 from dotenv import load_dotenv
 from flask import Flask, jsonify
 
-from src.fetch.dune_cached import CachedDuneFetcher
+from src.fetch.affiliate_data import CachingAffiliateFetcher
 from src.logger import set_log
 
 app = Flask(__name__)
 load_dotenv()
-cached_fetcher = CachedDuneFetcher(
+cached_fetcher = CachingAffiliateFetcher(
     api_key=os.environ["DUNE_API_KEY"],
     execution_id=os.environ.get("LAST_EXECUTION_ID"),
     cache_validity=int(os.environ["CACHE_VALIDITY"]),

--- a/src/api/affiliate.py
+++ b/src/api/affiliate.py
@@ -1,0 +1,34 @@
+"""Basic Flask API"""
+import os
+from typing import Any
+
+from dotenv import load_dotenv
+from flask import Flask, jsonify
+
+from src.fetch.dune_cached import CachedDuneFetcher
+from src.logger import set_log
+
+app = Flask(__name__)
+load_dotenv()
+cached_fetcher = CachedDuneFetcher(
+    api_key=os.environ["DUNE_API_KEY"],
+    execution_id=os.environ.get("LAST_EXECUTION_ID"),
+    cache_validity=int(os.environ["CACHE_VALIDITY"]),
+)
+log = set_log(__name__)
+
+
+@app.route("/profile/<string:address>", methods=["GET"])
+def get_profile(address: str) -> Any:
+    """
+    Fetches Affiliate Profile for `address`
+    https://api.cow.fi/affiliate/api/v1/profile/<address>
+    """
+    log.info(f"Fetching affiliate data for {address}")
+    affiliate_data = cached_fetcher.get_affiliate_data(account=address)
+    log.debug(f"got results {affiliate_data}")
+    return jsonify(affiliate_data)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/api/affiliate.py
+++ b/src/api/affiliate.py
@@ -5,18 +5,18 @@ from typing import Any
 from dotenv import load_dotenv
 from dune_client.client import DuneClient
 from flask import Flask, jsonify
+from flask.logging import create_logger
 
 from src.fetch.affiliate_data import CachingAffiliateFetcher
-from src.logger import set_log
 
 app = Flask(__name__)
+log = create_logger(app)
 load_dotenv()
 cached_fetcher = CachingAffiliateFetcher(
     dune=DuneClient(os.environ["DUNE_API_KEY"]),
     execution_id=os.environ.get("LAST_EXECUTION_ID"),
     cache_validity=int(os.environ["CACHE_VALIDITY"]),
 )
-log = set_log(__name__)
 
 
 @app.route("/profile/<string:address>", methods=["GET"])
@@ -26,8 +26,11 @@ def get_profile(address: str) -> Any:
     https://api.cow.fi/affiliate/api/v1/profile/<address>
     """
     log.info(f"Fetching affiliate data for {address}")
-    affiliate_data = cached_fetcher.get_affiliate_data(account=address)
-    log.debug(f"got results {affiliate_data}")
+    try:
+        affiliate_data = cached_fetcher.get_affiliate_data(account=address)
+    except ValueError as err:
+        return str(err), 400
+
     return jsonify(affiliate_data)
 
 

--- a/src/fetch/affiliate_data.py
+++ b/src/fetch/affiliate_data.py
@@ -58,7 +58,7 @@ class AffiliateMemory:
     last_execution: str
 
 
-class CachedDuneFetcher:
+class CachingAffiliateFetcher:
     """
     Class containing, DuneClient, FileIO and a logger for convenient Dune Fetching.
     """

--- a/src/fetch/dune_cached.py
+++ b/src/fetch/dune_cached.py
@@ -1,0 +1,126 @@
+"""Caching Dune affiliate data fetcher"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional
+
+from dune_client.client import DuneClient
+from dune_client.query import Query
+from dune_client.types import DuneRecord
+
+from src.logger import set_log
+from src.utils import utc_now, valid_address
+
+AFFILIATE_QUERY_ID = 1757231
+log = set_log(__name__)
+
+
+@dataclass
+class AffiliateData:  # pylint: disable=invalid-name
+    """Represents the affiliate API return type"""
+
+    totalTrades: int
+    tradeVolumeUsd: float
+    totalReferrals: int
+    referralVolumeUsd: float
+    lastUpdated: Optional[datetime]
+
+    @classmethod
+    def from_dict(cls, data_dict: DuneRecord, last_update: datetime) -> AffiliateData:
+        """Constructor of data class from DuneRecord or any dict with compatible types"""
+        return cls(
+            totalTrades=int(data_dict["total_trades"]),
+            totalReferrals=int(data_dict["total_referrals"]),
+            tradeVolumeUsd=float(data_dict["trade_volume_usd"]),
+            referralVolumeUsd=float(data_dict["referral_volume_usd"]),
+            lastUpdated=last_update,
+        )
+
+    @classmethod
+    def default(cls) -> AffiliateData:
+        """Default return type for NotFound affiliates"""
+        return cls(
+            totalTrades=0,
+            totalReferrals=0,
+            tradeVolumeUsd=0.0,
+            referralVolumeUsd=0.0,
+            lastUpdated=None,
+        )
+
+
+@dataclass
+class AffiliateMemory:
+    """Indexed affiliate data with knowledge of data's age"""
+
+    data: dict[str, AffiliateData]
+    last_update: datetime
+    last_execution: str
+
+
+class CachedDuneFetcher:
+    """
+    Class containing, DuneClient, FileIO and a logger for convenient Dune Fetching.
+    """
+
+    def __init__(
+        self, api_key: str, execution_id: Optional[str], cache_validity: int = 30
+    ) -> None:
+        """
+        Class constructor.
+        Builds DuneClient from `api_key`.
+        - `cache_validity` is in minutes.
+        - `execution_id` can be used to avoid initial fetching if known
+        """
+        log.info("loading affiliate data cache")
+        self.dune = DuneClient(api_key)
+        self.memory: AffiliateMemory = self._fetch_affiliates(execution_id)
+        self.cache_validity = timedelta(minutes=cache_validity)
+        log.info("affiliate data cache loaded")
+
+    def _fetch_affiliates(self, execution_id: Optional[str] = None) -> AffiliateMemory:
+        """Fetches Affiliate data from Dune and updates cache"""
+        if execution_id:
+            results = self.dune.get_result(execution_id)
+        else:
+            results = self.dune.refresh(Query(AFFILIATE_QUERY_ID), ping_frequency=10)
+
+        last_update = results.times.execution_ended_at or utc_now()
+        return AffiliateMemory(
+            last_update=last_update,
+            last_execution=results.execution_id,
+            data={
+                row["trader"]: AffiliateData.from_dict(row, last_update=last_update)
+                for row in results.get_rows()
+            },
+        )
+
+    def _update_memory(self) -> None:
+        """Internal method to update the cached affiliate data"""
+        self.memory = self._fetch_affiliates()
+
+    def cache_expired(self) -> bool:
+        """
+        Determines if data cache is expired.
+        """
+        before = self.memory.last_update
+        delta = self.cache_validity
+        return utc_now() > before + delta
+
+    def get_affiliate_data(self, account: str) -> AffiliateData:
+        """
+        Returns affiliate data for `account`.
+        If the record on hand is considered "too old",
+        refreshes memory before return.
+        """
+        if not valid_address(account):
+            log.warning(f"Invalid address received {account}")
+
+        if self.cache_expired():
+            log.debug("cache expired - refreshing results")
+            self._update_memory()
+
+        clean_address = account.lower()
+        result = self.memory.data.get(clean_address, AffiliateData.default())
+        log.debug(f"Found result for {account}: {result}")
+        return result

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,7 @@
 """Basic reusable utility functions"""
 import os
+import re
+from datetime import datetime, timezone
 
 from src.environment import QUERY_PATH
 
@@ -13,3 +15,16 @@ def open_query(filename: str) -> str:
 def query_file(filename: str) -> str:
     """Returns proper path for filename in QUERY_PATH"""
     return os.path.join(QUERY_PATH, filename)
+
+
+def valid_address(address: str) -> bool:
+    """Validates Ethereum addresses"""
+    match_result = re.match(
+        pattern=r"^(0x)?[0-9a-f]{40}$", string=address, flags=re.IGNORECASE
+    )
+    return match_result is not None
+
+
+def utc_now() -> datetime:
+    """Returns current UTC time"""
+    return datetime.now(tz=timezone.utc)

--- a/tests/integration/test_caching_affiliate_fetcher.py
+++ b/tests/integration/test_caching_affiliate_fetcher.py
@@ -1,0 +1,38 @@
+import os
+import os
+import unittest
+
+from dune_client.client import DuneClient
+
+from src.fetch.affiliate_data import (
+    CachingAffiliateFetcher,
+)
+
+
+class TestCachingAffiliateFetcher(unittest.TestCase):
+    """This test requires valid API Key"""
+
+    def setUp(self) -> None:
+        self.dune = DuneClient(os.environ["DUNE_API_KEY"])
+
+    def test_affiliate_fetching(self):
+        fetcher = CachingAffiliateFetcher(self.dune, execution_id=None)
+        known_trader_and_referrer = "0x0d5dc686d0a2abbfdafdfb4d0533e886517d4e83"
+        affiliate_data = fetcher.get_affiliate_data(known_trader_and_referrer)
+        # As of January 17, 2023
+        self.assertGreater(affiliate_data.totalTrades, 241)
+        self.assertGreater(affiliate_data.totalReferrals, 7)
+        self.assertGreater(affiliate_data.tradeVolumeUsd, 75687577)
+        self.assertGreater(affiliate_data.referralVolumeUsd, 75788291)
+
+    def test_affiliate_fetching_deterministic(self):
+        fetcher = CachingAffiliateFetcher(
+            self.dune, execution_id="01GQ0YASEDSE1W7MENGTT1Q3AJ"
+        )
+        known_trader_and_referrer = "0x0d5dc686d0a2abbfdafdfb4d0533e886517d4e83"
+        affiliate_data = fetcher.get_affiliate_data(known_trader_and_referrer)
+
+        self.assertEqual(affiliate_data.totalTrades, 242)
+        self.assertEqual(affiliate_data.totalReferrals, 8)
+        self.assertAlmostEqual(affiliate_data.tradeVolumeUsd, 75687577.26913233)
+        self.assertAlmostEqual(affiliate_data.referralVolumeUsd, 75788291.13699351)

--- a/tests/unit/test_affiliate_data.py
+++ b/tests/unit/test_affiliate_data.py
@@ -1,0 +1,265 @@
+import datetime
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from dune_client.client import DuneClient
+from dune_client.models import (
+    ResultsResponse,
+    ExecutionState,
+    ExecutionResult,
+    TimeData,
+    ResultMetadata,
+)
+
+from src.fetch.affiliate_data import (
+    AffiliateData,
+    AffiliateMemory,
+    CachingAffiliateFetcher,
+)
+
+
+class TestCachingAffiliateFetcher(unittest.TestCase):
+    """This test Mocks the Dune Client"""
+
+    def setUp(self) -> None:
+        self.dummy_times = TimeData(
+            submitted_at=datetime.datetime(1970, 1, 1),
+            cancelled_at=None,
+            expires_at=None,
+            execution_ended_at=None,
+            execution_started_at=None,
+        )
+        self.dummy_metadata = ResultMetadata(
+            column_names=[],
+            datapoint_count=1,
+            execution_time_millis=1,
+            pending_time_millis=None,
+            result_set_bytes=1,
+            total_row_count=1,
+        )
+        self.empty_refresh_response = ResultsResponse(
+            execution_id="1",
+            query_id=1,
+            state=ExecutionState.COMPLETED,
+            result=ExecutionResult(
+                rows=[],
+                metadata=self.dummy_metadata,
+            ),
+            times=self.dummy_times,
+        )
+        self.trader = "0x1"
+        self.get_result_response = ResultsResponse(
+            execution_id="3",
+            query_id=1,
+            state=ExecutionState.COMPLETED,
+            result=ExecutionResult(
+                rows=[
+                    {
+                        "trader": self.trader,
+                        "total_trades": "4",
+                        "total_referrals": "5",
+                        "trade_volume_usd": "156.7",
+                        "referral_volume_usd": "18.9",
+                    }
+                ],
+                metadata=self.dummy_metadata,
+            ),
+            times=self.dummy_times,
+        )
+
+    def test_cache_expired(self):
+        mock_dune = DuneClient("api_key")
+        mock_dune.refresh = MagicMock(return_value=self.empty_refresh_response)
+        seconds = 3
+        affiliate_fetcher = CachingAffiliateFetcher(
+            dune=mock_dune, cache_validity=seconds / 60.0, execution_id=None
+        )
+        self.assertEqual(affiliate_fetcher.cache_expired(), False)
+        time.sleep(seconds)
+        self.assertEqual(affiliate_fetcher.cache_expired(), True)
+
+    def test_get_affiliate_data_refresh(self):
+        mock_dune = DuneClient("api_key")
+        affiliate_result = {
+            "trader": self.trader,
+            "total_trades": "3",
+            "total_referrals": "4",
+            "trade_volume_usd": "56.7",
+            "referral_volume_usd": "8.9",
+        }
+        mock_dune.refresh = MagicMock(
+            return_value=ResultsResponse(
+                execution_id="2",
+                query_id=1,
+                state=ExecutionState.COMPLETED,
+                result=ExecutionResult(
+                    rows=[affiliate_result],
+                    metadata=self.dummy_metadata,
+                ),
+                times=self.dummy_times,
+            )
+        )
+        affiliate_fetcher = CachingAffiliateFetcher(dune=mock_dune, execution_id=None)
+        self.assertEqual(
+            affiliate_fetcher.get_affiliate_data(self.trader),
+            AffiliateData.from_dict(
+                affiliate_result, last_update=affiliate_fetcher.memory.last_update
+            ),
+        )
+
+        random_address = "0x123"
+        self.assertEqual(
+            affiliate_fetcher.get_affiliate_data(random_address),
+            AffiliateData.default(),
+        )
+
+    def test_get_affiliate_data_from_execution_id(self):
+        mock_dune = DuneClient("api_key")
+        affiliate_result = {
+            "trader": self.trader,
+            "total_trades": "4",
+            "total_referrals": "5",
+            "trade_volume_usd": "156.7",
+            "referral_volume_usd": "18.9",
+        }
+        mock_dune.get_result = MagicMock(
+            return_value=ResultsResponse(
+                execution_id="3",
+                query_id=1,
+                state=ExecutionState.COMPLETED,
+                result=ExecutionResult(
+                    rows=[affiliate_result],
+                    metadata=self.dummy_metadata,
+                ),
+                times=self.dummy_times,
+            )
+        )
+        affiliate_fetcher = CachingAffiliateFetcher(dune=mock_dune, execution_id="3")
+        self.assertEqual(
+            affiliate_fetcher.get_affiliate_data(self.trader),
+            AffiliateData.from_dict(
+                affiliate_result, last_update=affiliate_fetcher.memory.last_update
+            ),
+        )
+
+        random_address = "0x123"
+        self.assertEqual(
+            affiliate_fetcher.get_affiliate_data(random_address),
+            AffiliateData.default(),
+        )
+
+    def test_update_memory(self):
+        mock_dune = DuneClient("api_key")
+        affiliate_result_after = {
+            "trader": self.trader,
+            "total_trades": "4",
+            "total_referrals": "5",
+            "trade_volume_usd": "156.7",
+            "referral_volume_usd": "18.9",
+        }
+        mock_dune.get_result = MagicMock(
+            return_value=ResultsResponse(
+                execution_id="3",
+                query_id=1,
+                state=ExecutionState.COMPLETED,
+                result=ExecutionResult(
+                    rows=[],
+                    metadata=self.dummy_metadata,
+                ),
+                times=self.dummy_times,
+            )
+        )
+        mock_dune.refresh = MagicMock(
+            return_value=ResultsResponse(
+                execution_id="4",
+                query_id=1,
+                state=ExecutionState.COMPLETED,
+                result=ExecutionResult(
+                    rows=[affiliate_result_after],
+                    metadata=self.dummy_metadata,
+                ),
+                times=self.dummy_times,
+            )
+        )
+        # Initialize with results from execution id (i.e. mocked get_result)
+        seconds = 3
+        affiliate_fetcher = CachingAffiliateFetcher(
+            dune=mock_dune, execution_id="3", cache_validity=3 / 60.0
+        )
+        # Initially no results for this trader.
+        self.assertEqual(
+            affiliate_fetcher.get_affiliate_data(self.trader),
+            AffiliateData.default(),
+        )
+        time.sleep(3)
+        self.assertEqual(
+            affiliate_fetcher.get_affiliate_data(self.trader),
+            AffiliateData(
+                totalTrades=4,
+                tradeVolumeUsd=156.7,
+                totalReferrals=5,
+                referralVolumeUsd=18.9,
+                lastUpdated=affiliate_fetcher.memory.last_update,
+            ),
+        )
+
+
+class TestAffiliateData(unittest.TestCase):
+    def test_from_dict(self):
+        update = datetime.datetime(1970, 1, 1)
+        self.assertEqual(
+            AffiliateData.from_dict(
+                {
+                    "total_trades": "1",
+                    "total_referrals": "2",
+                    "trade_volume_usd": "123.4",
+                    "referral_volume_usd": "567.8",
+                },
+                last_update=update,
+            ),
+            AffiliateData(
+                totalTrades=1,
+                tradeVolumeUsd=123.4,
+                totalReferrals=2,
+                referralVolumeUsd=567.8,
+                lastUpdated=update,
+            ),
+        )
+
+    def test_default(self):
+        self.assertEqual(
+            AffiliateData.default(),
+            AffiliateData(
+                totalTrades=0,
+                tradeVolumeUsd=0,
+                totalReferrals=0,
+                referralVolumeUsd=0,
+                lastUpdated=None,
+            ),
+        )
+
+
+class TestAffiliateMemory(unittest.TestCase):
+    def test_constructor(self):
+        last_update = datetime.datetime(1970, 1, 1)
+        last_execution_id = "ExecutionID"
+        data = {
+            "0x1": AffiliateData(
+                totalTrades=1,
+                tradeVolumeUsd=123.4,
+                totalReferrals=2,
+                referralVolumeUsd=567.8,
+                lastUpdated=last_update,
+            )
+        }
+        memory = AffiliateMemory(data, last_update, last_execution_id)
+        # This test is kinda meaningless,
+        # but would fail if someone changed the constructor in an unexpected way.
+        self.assertEqual(memory.data, data)
+        self.assertEqual(memory.last_update, last_update)
+        self.assertEqual(memory.last_execution_id, last_execution_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,22 @@
+import unittest
+
+from src.utils import valid_address, utc_now
+
+
+class TestUtils(unittest.TestCase):
+    def test_valid_address(self):
+        checksum_address = "0x473780deAF4a2Ac070BBbA936B0cdefe7F267dFc"
+        lower_address = checksum_address.lower()
+        upper_address = lower_address.upper()
+        self.assertEqual(valid_address("abc"), False)
+        self.assertEqual(valid_address(lower_address), True)
+        self.assertEqual(valid_address(upper_address), True)
+        self.assertEqual(valid_address(checksum_address), True)
+
+    def test_utc_now(self):
+        now = utc_now()
+        self.assertEqual(now.tzname(), "UTC")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Related to https://github.com/cowprotocol/dune-bridge/issues/52

This PR implements the last change to fully replace the Dune Bridge project.

- A basic API endpoint for user account profiles
- When the address is not a user or an invalid string, default (zero) profile is returned

## TODO

Add more tests (e.g. for API route)

## Test Plan 

Run the API server (requires Dune API key)

Try it out
```
http://127.0.0.1:5000/profile/xyz
127.0.0.1:5000/profile/0x247b317521d7edcfaf9b6d6c21b55217e5c34e0a
```