### PR TITLE
[Schema] Add block_number to order_rewards

### DIFF
--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -50,16 +50,8 @@ class OrderbookFetcher:
         cls, query: str, env: OrderbookEnv, data_types: Optional[dict[str, str]] = None
     ) -> DataFrame:
         # It seems there is a bug in mypy on the dtype field (with error [arg-type]).
-        # They expect types that I believe match what we pass,
-        # but also don't provide a public interface to import their types
-        # Also using numpy types like `np.int64` doesn't work either.
-        # error: Argument "dtype" to "read_sql_query" has incompatible type "Dict[str, str]";
-        # expected "Optional[Union[Union[ExtensionDtype, Union[str, dtype[generic], Type[str],
-        # Type[complex], Type[bool], Type[object]]], Dict[Any, Union[ExtensionDtype,
-        # Union[str, dtype[generic], Type[str], Type[complex], Type[bool], Type[object]]]]]]"
-        # ---
-        # When attempting to import expected type declarations,
-        # like DType, we are faces with private interface pandas._typing
+        # They expect types that should align with what we pass.
+        # More context at: https://github.com/cowprotocol/dune-sync/issues/24
         return pd.read_sql_query(query, con=cls._pg_engine(env), dtype=data_types)  # type: ignore
 
     @classmethod

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -49,6 +49,17 @@ class OrderbookFetcher:
     def _read_query_for_env(
         cls, query: str, env: OrderbookEnv, data_types: Optional[dict[str, str]] = None
     ) -> DataFrame:
+        # It seems there is a bug in mypy on the dtype field.
+        # They expect types that I believe match what we pass,
+        # but also don't provide a public interface to import their types
+        # Also using numpy types like `np.int64` doesn't work either.
+        # error: Argument "dtype" to "read_sql_query" has incompatible type "Dict[str, str]";
+        # expected "Optional[Union[Union[ExtensionDtype, Union[str, dtype[generic], Type[str], Type[complex],
+        # Type[bool], Type[object]]], Dict[Any, Union[ExtensionDtype, Union[str, dtype[generic], Type[str],
+        # Type[complex], Type[bool], Type[object]]]]]]"  [arg-type]
+        # ---
+        # When attempting to import expected type declarations,
+        # like DType, we are faces with private interface pandas._typing
         return pd.read_sql_query(query, con=cls._pg_engine(env), dtype=data_types)  # type: ignore
 
     @classmethod

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -45,9 +45,16 @@ class OrderbookFetcher:
         return create_engine(db_string)
 
     @classmethod
+    def _read_query_for_env(
+        cls, query: str, env: OrderbookEnv, data_types: dict[str, str]
+    ) -> DataFrame:
+        return pd.read_sql_query(query, con=cls._pg_engine(env), dtype=data_types)  # type: ignore
+
+    @classmethod
     def _query_both_dbs(cls, query: str) -> tuple[DataFrame, DataFrame]:
-        barn = pd.read_sql(query, con=cls._pg_engine(OrderbookEnv.BARN))
-        prod = pd.read_sql(query, con=cls._pg_engine(OrderbookEnv.PROD))
+        data_types = {"block_number": "int64", "amount": "float64"}
+        barn = cls._read_query_for_env(query, OrderbookEnv.BARN, data_types)
+        prod = cls._read_query_for_env(query, OrderbookEnv.PROD, data_types)
         return barn, prod
 
     @classmethod

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -49,14 +49,14 @@ class OrderbookFetcher:
     def _read_query_for_env(
         cls, query: str, env: OrderbookEnv, data_types: Optional[dict[str, str]] = None
     ) -> DataFrame:
-        # It seems there is a bug in mypy on the dtype field.
+        # It seems there is a bug in mypy on the dtype field (with error [arg-type]).
         # They expect types that I believe match what we pass,
         # but also don't provide a public interface to import their types
         # Also using numpy types like `np.int64` doesn't work either.
         # error: Argument "dtype" to "read_sql_query" has incompatible type "Dict[str, str]";
-        # expected "Optional[Union[Union[ExtensionDtype, Union[str, dtype[generic], Type[str], Type[complex],
-        # Type[bool], Type[object]]], Dict[Any, Union[ExtensionDtype, Union[str, dtype[generic], Type[str],
-        # Type[complex], Type[bool], Type[object]]]]]]"  [arg-type]
+        # expected "Optional[Union[Union[ExtensionDtype, Union[str, dtype[generic], Type[str],
+        # Type[complex], Type[bool], Type[object]]], Dict[Any, Union[ExtensionDtype,
+        # Union[str, dtype[generic], Type[str], Type[complex], Type[bool], Type[object]]]]]]"
         # ---
         # When attempting to import expected type declarations,
         # like DType, we are faces with private interface pandas._typing

--- a/src/models/order_rewards_schema.py
+++ b/src/models/order_rewards_schema.py
@@ -18,6 +18,7 @@ class OrderRewards:
         """Converts Pandas DataFrame into the expected stream type for Dune"""
         return [
             {
+                "block_number": int(row["block_number"]),
                 "order_uid": row["order_uid"],
                 "tx_hash": row["tx_hash"],
                 "solver": row["solver"],

--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -1,4 +1,5 @@
 with trade_hashes as (SELECT solver,
+                             block_number,
                              order_uid,
                              fee_amount,
                              settlement.tx_hash,
@@ -20,7 +21,8 @@ with trade_hashes as (SELECT solver,
                       where block_number > {{start_block}} and block_number <= {{end_block}})
 
 -- Most efficient column order for sorting would be having tx_hash or order_uid first
-select concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
+select block_number,
+       concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
        concat('0x', encode(solver, 'hex'))  as solver,
        concat('0x', encode(tx_hash, 'hex')) as tx_hash,
        coalesce(surplus_fee, 0)::text       as surplus_fee,

--- a/tests/integration/test_fetch_orderbook.py
+++ b/tests/integration/test_fetch_orderbook.py
@@ -18,7 +18,6 @@ class TestFetchOrderbook(unittest.TestCase):
         block_number = 16000000
         block_range = BlockRange(block_number, block_number + 50)
         rewards_df = OrderbookFetcher.get_orderbook_rewards(block_range)
-        print(rewards_df.keys())
         expected = pd.DataFrame(
             {
                 "block_number": [16000018, 16000050],

--- a/tests/integration/test_fetch_orderbook.py
+++ b/tests/integration/test_fetch_orderbook.py
@@ -18,8 +18,10 @@ class MyTestCase(unittest.TestCase):
         block_number = 16000000
         block_range = BlockRange(block_number, block_number + 50)
         rewards_df = OrderbookFetcher.get_orderbook_rewards(block_range)
+        print(rewards_df.keys())
         expected = pd.DataFrame(
             {
+                "block_number": [16000018, 16000050],
                 "order_uid": [
                     "0xb52fecfe3df73f0e93f1f9b27c92e3def50322960f9c62d0b97bc2ceee36c07a0639dda84198dc06f5bc91bddbb62cd2e38c2f9a6378140f",
                     "0xf61cba0b42ed3e956f9db049c0523e123967723c5bcf76ccac0b179a66305b2a7fee439ed7a6bb1b8e7ca1ffdb0a5ca8d993c030637815ad",

--- a/tests/integration/test_fetch_orderbook.py
+++ b/tests/integration/test_fetch_orderbook.py
@@ -6,7 +6,7 @@ from src.fetch.orderbook import OrderbookFetcher
 from src.models.block_range import BlockRange
 
 
-class MyTestCase(unittest.TestCase):
+class TestFetchOrderbook(unittest.TestCase):
     def test_latest_block_reasonable(self):
         self.assertGreater(OrderbookFetcher.get_latest_block(), 16020300)
 

--- a/tests/unit/test_order_rewards_schema.py
+++ b/tests/unit/test_order_rewards_schema.py
@@ -9,6 +9,7 @@ class TestModelOrderRewards(unittest.TestCase):
     def test_order_rewards_transformation(self):
         rewards_df = pd.DataFrame(
             {
+                "block_number": [1, 2, 3],
                 "order_uid": ["0x01", "0x02", "0x03"],
                 "solver": ["0x51", "0x52", "0x53"],
                 "tx_hash": ["0x71", "0x72", "0x73"],
@@ -20,6 +21,7 @@ class TestModelOrderRewards(unittest.TestCase):
         self.assertEqual(
             [
                 {
+                    "block_number": 1,
                     "order_uid": "0x01",
                     "solver": "0x51",
                     "tx_hash": "0x71",
@@ -29,6 +31,7 @@ class TestModelOrderRewards(unittest.TestCase):
                     },
                 },
                 {
+                    "block_number": 2,
                     "order_uid": "0x02",
                     "solver": "0x52",
                     "tx_hash": "0x72",
@@ -38,6 +41,7 @@ class TestModelOrderRewards(unittest.TestCase):
                     },
                 },
                 {
+                    "block_number": 3,
                     "order_uid": "0x03",
                     "solver": "0x53",
                     "tx_hash": "0x73",


### PR DESCRIPTION
For query efficiency reasons, we would need to include block number on the order rewards table in our community sources (this will allow us to join on trades more efficiently). 

⚠️ - this will require coordination with Dune on Redeployment. cc @dsalv

### Test Plan 

Existing Unit tests which have been adapted.