### PR TITLE
Add Utility Scripts (empty_bucket & download_file)

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -6,4 +6,4 @@ pandas>=1.5.0
 ndjson>=0.3.1
 py-multiformats-cid>=0.4.4
 boto3>=1.26.12
-SQLAlchemy>=1.4.44
+SQLAlchemy<2.0

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,6 @@ import argparse
 import asyncio
 import logging.config
 import os
-import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,11 +10,11 @@ from dotenv import load_dotenv
 
 from src.fetch.dune import DuneFetcher
 from src.fetch.orderbook import OrderbookFetcher
+from src.models.tables import SyncTable
 from src.post.aws import AWSClient
 from src.sync import sync_app_data
 from src.sync.config import SyncConfig, AppDataSyncConfig
 from src.sync.order_rewards import sync_order_rewards
-from src.models.tables import SyncTable
 
 log = logging.getLogger(__name__)
 logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s")

--- a/src/main.py
+++ b/src/main.py
@@ -44,13 +44,6 @@ class ScriptArgs:
             help="Flag indicating whether script should not post files to AWS or not",
             default=False,
         )
-        parser.add_argument(
-            "--hard-reset",
-            type=bool,
-            help="Flag indicating whether the existing sync table data should "
-            "be deleted from the bucket and rebuilt from scratch",
-            default=False,
-        )
         arguments, _ = parser.parse_known_args()
         self.sync_table: SyncTable = arguments.sync_table
         self.dry_run: bool = arguments.dry_run
@@ -62,11 +55,6 @@ if __name__ == "__main__":
     volume_path = Path(os.environ["VOLUME_PATH"])
     args = ScriptArgs()
     aws = AWSClient.new_from_environment()
-    if args.hard_reset and not args.dry_run:
-        # Drop Data from AWS bucket
-        aws.delete_all(args.sync_table)
-        # drop backup data from volume path
-        shutil.rmtree(volume_path / str(args.sync_table))
 
     if args.sync_table == SyncTable.APP_DATA:
         asyncio.run(

--- a/src/post/aws.py
+++ b/src/post/aws.py
@@ -237,9 +237,12 @@ class AWSClient:
 
     def delete_all(self, table: SyncTable | str) -> None:
         """Deletes all files within the supported tables directory"""
+        log.info(f"Emptying Bucket {table}")
         try:
             table_files = self.existing_files().get(table)
+            log.info(f"Found {len(table_files)} files to be removed.")
             for file_data in table_files:
+                log.info(f"Deleting file {file_data.object_key}")
                 self.delete_file(file_data.object_key)
         except KeyError as err:
             raise ValueError(

--- a/src/scripts/download_file.py
+++ b/src/scripts/download_file.py
@@ -1,0 +1,26 @@
+"""Downloads file from AWS to PWD"""
+import argparse
+
+from dotenv import load_dotenv
+
+from src.post.aws import AWSClient
+
+
+def download_file(aws: AWSClient, object_key: str) -> None:
+    """Download file (`object_key`) from AWS"""
+    aws.download_file(
+        filename=object_key.split("/")[1],
+        object_key=object_key,
+    )
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    parser = argparse.ArgumentParser("Download File from Bucket")
+    parser.add_argument(
+        "filename",
+        type=str,
+        required=True,
+    )
+    args, _ = parser.parse_known_args()
+    download_file(aws=AWSClient.new_from_environment(), object_key=args.object_key)

--- a/src/scripts/empty_bucket.py
+++ b/src/scripts/empty_bucket.py
@@ -1,0 +1,33 @@
+"""
+Script to empty AWS bucket.
+Used for re-deployments involving schema change.
+"""
+import os
+import shutil
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from src.main import ScriptArgs
+from src.models.tables import SyncTable
+from src.post.aws import AWSClient
+
+
+def empty_bucket(table: SyncTable, aws: AWSClient, volume_path: Path) -> None:
+    """
+    Empties the bucket for `table`
+    and deletes backup from mounted volume
+    """
+    # Drop Data from AWS bucket
+    aws.delete_all(table)
+    # drop backup data from volume path
+    shutil.rmtree(volume_path / str(table))
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    empty_bucket(
+        table=ScriptArgs().sync_table,
+        aws=AWSClient.new_from_environment(),
+        volume_path=Path(os.environ["VOLUME_PATH"]),
+    )

--- a/tests/integration/test_aws.py
+++ b/tests/integration/test_aws.py
@@ -66,6 +66,14 @@ class TestAWSConnection(unittest.TestCase):
         # File was downloaded!
         self.assertTrue(exists(self.empty_file))
 
+    def test_download_specific_file(self):
+        success = self.aws_client.download_file(
+            filename="cow_16434617.json",
+            object_key="order_rewards/cow_16434617.json",
+        )
+        self.assertTrue(success)
+        # File was downloaded!
+
     def test_delete_file(self):
         self.create_upload_remove()
         success = self.aws_client.delete_file(object_key=self.key)


### PR DESCRIPTION
There is no UI to view and manage files in the AWS buckets, so when we want to peek a file we can `download_file`. Furthermore (and more importantly), the script argument `hard-reset` didn't make sense to include in our deployments since we would only every want to do this once. So instead we provided an independent utility script to `empty_bucket` which should be done (one time) before deploying schema changes.

This was already used recently for deployment of the changes to order rewards made in #23.