### PR TITLE
[Batch Rewards] Orderbook Query for Batch Rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ So, the process is:
 docker run -v ${PWD}/data:/app/data \
     --env-file .env \
     ghcr.io/cowprotocol/dune-sync \
-    --sync-table SYNC_TABLE \
+    --sync-table SYNC_TABLE
 ```
 
 This will empty the buckets and repopulate with the appropriate changes.

--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -1,39 +1,43 @@
-with hashed_observations as (SELECT block_number,
-                                    tx_hash,
-                                    effective_gas_price * gas_used as execution_cost,
-                                    surplus,
-                                    fee,
-                                    auction_id
-                             FROM settlement_observations so
-                                    LEFT OUTER JOIN LATERAL (
-                               SELECT tx_hash, solver, tx_nonce, tx_from
-                               FROM settlements s
-                               WHERE s.block_number = so.block_number
-                                 AND s.log_index = so.log_index
-                               LIMIT 1
-                               ) AS settlement ON TRUE
-                                    JOIN auction_transaction
-                                         ON settlement.tx_from = auction_transaction.tx_from
-                                           AND settlement.tx_nonce = auction_transaction.tx_nonce
-                             WHERE block_number > {{start_block}} AND block_number <= {{end_block}}),
+WITH hashed_observations AS (
+SELECT
+    -- settlement
+    tx_hash,
+    -- settlement_observations
+    block_number,
+    effective_gas_price * gas_used AS execution_cost,
+    surplus,
+    fee,
+    -- auction_transaction
+    auction_id
+FROM settlement_observations so
+JOIN settlements s
+  ON s.block_number = so.block_number
+  AND s.log_index = so.log_index
+JOIN auction_transaction at
+  ON s.tx_from = at.tx_from
+  AND s.tx_nonce = at.tx_nonce
+WHERE block_number > {{start_block}} AND block_number <= {{end_block}}
+),
 
-     reward_data as (select
-                       -- observations
-                       block_number,
-                       tx_hash,
-                       execution_cost,
-                       surplus,
-                       fee,
-                       surplus + fee - reference_score as reward_eth,
-                       -- scores
-                       winning_score,
-                       reference_score,
-                       -- participation
-                       participants
-                     from hashed_observations ho
-                            join settlement_scores ss
-                                 on ho.auction_id = ss.auction_id
-                            join auction_participants ap
-                                 on ho.auction_id = ap.auction_id)
+reward_data AS (
+  SELECT
+     -- observations
+     block_number,
+     tx_hash,
+     execution_cost,
+     surplus,
+     fee,
+     surplus + fee - reference_score AS reward_eth,
+     -- scores
+     winning_score,
+     reference_score,
+     -- participation
+     participants
+FROM hashed_observations ho
+JOIN settlement_scores ss
+  ON ho.auction_id = ss.auction_id
+JOIN auction_participants ap
+  ON ho.auction_id = ap.auction_id
+)
 
-select * from reward_data
+SELECT * FROM reward_data

--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -1,0 +1,45 @@
+with
+hashed_observations as (
+  SELECT
+    block_number,
+    tx_hash,
+    effective_gas_price * gas_used as execution_cost,
+    surplus,
+    fee,
+    auction_id
+  FROM settlement_observations so
+  LEFT OUTER JOIN LATERAL (
+    SELECT tx_hash, solver, tx_nonce, tx_from
+    FROM settlements s
+    WHERE s.block_number = so.block_number
+      AND s.log_index > so.log_index
+    ORDER BY s.log_index
+    LIMIT 1
+  ) AS settlement
+    ON TRUE
+  JOIN auction_transaction
+     ON settlement.tx_from = auction_transaction.tx_from
+    AND settlement.tx_nonce = auction_transaction.tx_nonce
+  WHERE block_number > {{start_block}} AND block_number <= {{end_block}}
+)
+
+select
+    -- observations
+    block_number,
+    tx_hash,
+    execution_cost,
+    surplus,
+    fee,
+    surplus + fee - reference_score as reward_eth,
+    -- scores
+    winning_score,
+    reference_score,
+    -- participation
+    participants
+from hashed_observations ho
+-- may want to do outer joins
+join settlement_scores ss
+  on ho.auction_id = ss.auction_id
+-- may want to do outer joins
+join auction_participants ap
+  on ho.auction_id = ap.auction_id

--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -2,6 +2,7 @@ WITH observed_settlements AS (
 SELECT
     -- settlement
     tx_hash,
+    solver,
     -- settlement_observations
     block_number,
     effective_gas_price * gas_used AS execution_cost,
@@ -23,6 +24,11 @@ reward_data AS (
   SELECT
     -- observations
     tx_hash,
+    coalesce(
+      solver,
+      -- This is the winning solver (i.e. last entry of participants array)
+      participants[array_length(participants, 1)]
+    ) as solver,
     -- Right-hand terms in coalesces below represent the case when settlement
     -- observations are unavailable (i.e. no settlement corresponds to reported scores).
     -- In particular, this means that surplus, fee and execution cost are all zero.
@@ -37,7 +43,7 @@ reward_data AS (
     winning_score,
     reference_score,
     -- participation
-    participants  -- TODO: Extract winning solver as well here
+    participants
 FROM settlement_scores ss
 -- If there are reported scores,
 -- there will always be a record of auction participants

--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -1,45 +1,42 @@
-with
-hashed_observations as (
-  SELECT
-    block_number,
-    tx_hash,
-    effective_gas_price * gas_used as execution_cost,
-    surplus,
-    fee,
-    auction_id
-  FROM settlement_observations so
-  LEFT OUTER JOIN LATERAL (
-    SELECT tx_hash, solver, tx_nonce, tx_from
-    FROM settlements s
-    WHERE s.block_number = so.block_number
-      AND s.log_index > so.log_index
-    ORDER BY s.log_index
-    LIMIT 1
-  ) AS settlement
-    ON TRUE
-  JOIN auction_transaction
-     ON settlement.tx_from = auction_transaction.tx_from
-    AND settlement.tx_nonce = auction_transaction.tx_nonce
-  WHERE block_number > {{start_block}} AND block_number <= {{end_block}}
-)
+with hashed_observations as (SELECT block_number,
+                                    tx_hash,
+                                    effective_gas_price * gas_used as execution_cost,
+                                    surplus,
+                                    fee,
+                                    auction_id
+                             FROM settlement_observations so
+                                    LEFT OUTER JOIN LATERAL (
+                               SELECT tx_hash, solver, tx_nonce, tx_from
+                               FROM settlements s
+                               WHERE s.block_number = so.block_number
+                                 AND s.log_index > so.log_index
+                               ORDER BY s.log_index
+                               LIMIT 1
+                               ) AS settlement ON TRUE
+                                    JOIN auction_transaction
+                                         ON settlement.tx_from = auction_transaction.tx_from
+                                           AND settlement.tx_nonce = auction_transaction.tx_nonce
+                             WHERE block_number > {{start_block}} AND block_number <= {{end_block}}),
 
-select
-    -- observations
-    block_number,
-    tx_hash,
-    execution_cost,
-    surplus,
-    fee,
-    surplus + fee - reference_score as reward_eth,
-    -- scores
-    winning_score,
-    reference_score,
-    -- participation
-    participants
-from hashed_observations ho
--- may want to do outer joins
-join settlement_scores ss
-  on ho.auction_id = ss.auction_id
--- may want to do outer joins
-join auction_participants ap
-  on ho.auction_id = ap.auction_id
+     reward_data as (select
+                       -- observations
+                       block_number,
+                       tx_hash,
+                       execution_cost,
+                       surplus,
+                       fee,
+                       surplus + fee - reference_score as reward_eth,
+                       -- scores
+                       winning_score,
+                       reference_score,
+                       -- participation
+                       participants
+                     from hashed_observations ho
+                            -- may want to do outer joins
+                            join settlement_scores ss
+                                 on ho.auction_id = ss.auction_id
+                       -- may want to do outer joins
+                            join auction_participants ap
+                                 on ho.auction_id = ap.auction_id)
+
+select * from reward_data

--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -9,8 +9,7 @@ with hashed_observations as (SELECT block_number,
                                SELECT tx_hash, solver, tx_nonce, tx_from
                                FROM settlements s
                                WHERE s.block_number = so.block_number
-                                 AND s.log_index > so.log_index
-                               ORDER BY s.log_index
+                                 AND s.log_index = so.log_index
                                LIMIT 1
                                ) AS settlement ON TRUE
                                     JOIN auction_transaction

--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -27,7 +27,7 @@ reward_data AS (
      execution_cost,
      surplus,
      fee,
-     surplus + fee - reference_score AS reward_eth,
+     surplus + fee - reference_score AS payment,
      -- scores
      winning_score,
      reference_score,

--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -34,9 +34,10 @@ reward_data AS (
      -- participation
      participants
 FROM hashed_observations ho
-JOIN settlement_scores ss
+-- outer joins made in order to detect missing data.
+LEFT OUTER JOIN settlement_scores ss
   ON ho.auction_id = ss.auction_id
-JOIN auction_participants ap
+LEFT OUTER JOIN auction_participants ap
   ON ho.auction_id = ap.auction_id
 )
 

--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -32,10 +32,8 @@ with hashed_observations as (SELECT block_number,
                        -- participation
                        participants
                      from hashed_observations ho
-                            -- may want to do outer joins
                             join settlement_scores ss
                                  on ho.auction_id = ss.auction_id
-                       -- may want to do outer joins
                             join auction_participants ap
                                  on ho.auction_id = ap.auction_id)
 


### PR DESCRIPTION
As part of #27 we implement the Raw Orderbook query that will be used to extract the data to be synced with Dune. The follow up to this PR will implement the python script executing this that is also responsible for transforming it into the JSON files being uploaded to Dune's AWS bucket.

Solvers are expected to change their rewards to the following

```
reward(txHash) = observedQuality - referenceScore
```
where `observedQuality = Surplus + Fee`

Furthermore, the reward per batch is planned to be capped by `[-E, E + executionCosts]  (E = 0.01 ETH)`

This query joins several tables in order to provide all terms required to evaluate the reward (namely surplus, fee, execution_cost, reference_score). `winning_score` is included too which is not really necessary but more for transparency.

Furthermore, it is expected that if the total allocated rewards for each accounting period are not reached, then we are to distribute the remaining funds according to the solver participation (found also as a field returned by this query).

For this, we might query something like (but this can come later).

```sql
participations as (
  select 
      tx_hash, 
      unnest(participants) as solver 
  from reward_data
)
select solver,
       count(distinct tx_hash) as num_solutions
from participations
group by solver
```


Trying to add @fhenneke as a reviewer to this, but can't.
 
 
Note that this is all based on the assumption that the following tables exist in the orderbook (introduced in https://github.com/cowprotocol/services/pull/1166)

```sql
CREATE TABLE settlement_scores (
  auction_id bigint PRIMARY KEY,
  winning_score numeric(78,0) NOT NULL,
  reference_score numeric(78,0) NOT NULL
);

CREATE TABLE settlement_observations (
  block_number bigint NOT NULL,
  log_index bigint NOT NULL,
  gas_used numeric(78,0) NOT NULL,
  effective_gas_price numeric(78,0) NOT NULL,
  surplus numeric(78,0) NOT NULL,
  fee numeric(78,0) NOT NULL,

  PRIMARY KEY (block_number, log_index)
);

CREATE TABLE auction_participants (
 auction_id bigint PRIMARY KEY,
 participants bytea[]
);
```

