### PR TITLE
[HotFix] Forgotten Instance of hard-reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker run -v ${PWD}/data:/app/data --env-file .env ghcr.io/cowprotocol/dune-syn
 ### Breaking Changes
 
 Whenever the schema changes, we must coordinate with Dune that the data must be dropped and the table rebuilt.
-For this we have implemented a feature flag `--hard-reset True` which can be called to delete all data from their 
+For this we have provided a script `scripts/empty_bucket.py` which can be called to delete all data from their 
 buckets and our backup volume. This should only be run whilst in coordination with their team about the changes. 
 They will "stop the stream", drop the table on their side and restart the stream. 
 In the event that a hard reset is performed without the proper coordination, 

--- a/src/main.py
+++ b/src/main.py
@@ -26,7 +26,6 @@ class ScriptArgs:
     """Runtime arguments' parser/initializer"""
 
     dry_run: bool
-    hard_reset: bool
     sync_table: SyncTable
 
     def __init__(self) -> None:
@@ -46,7 +45,6 @@ class ScriptArgs:
         arguments, _ = parser.parse_known_args()
         self.sync_table: SyncTable = arguments.sync_table
         self.dry_run: bool = arguments.dry_run
-        self.hard_reset: bool = arguments.hard_reset
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In #25 we removed hard-reset from the main script path but forgot to update the runtime argument configuration.

This removes it 

## Test Plan

Try running this script in try run mode (note - this requires a bunch of env vars). Trust me I did it.

```
git push --set-upstream origin hotfix-hardreset
```
![Screenshot 2023-02-20 at 17 17 05](https://user-images.githubusercontent.com/11778116/220156838-192459d3-89b6-4c0e-b3d3-6a68611e6e89.png)

