### PR TITLE
[Slippage V2] Sync Internal Transfers

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -49,3 +49,4 @@ jobs:
         env:
           PROD_DB_URL: ${{ secrets.PROD_DB_URL }}
           BARN_DB_URL: ${{ secrets.BARN_DB_URL }}
+          WAREHOUSE_URL: ${{ secrets.WAREHOUSE_URL }}

--- a/src/fetch/postgres.py
+++ b/src/fetch/postgres.py
@@ -1,0 +1,54 @@
+"""Generic Postgres Adapter for executing queries on a postgres DB."""
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+from pandas import DataFrame
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+from src.fetch.orderbook import REORG_THRESHOLD
+from src.models.block_range import BlockRange
+from src.utils import open_query
+
+
+@dataclass
+class PostgresFetcher:
+    """
+    Basic Postgres interface
+    """
+
+    engine: Engine
+
+    def __init__(self, db_url: str):
+        db_string = f"postgresql+psycopg2://{db_url}"
+
+        self.engine = create_engine(db_string)
+
+    def _read_query(
+        self, query: str, data_types: Optional[dict[str, str]] = None
+    ) -> DataFrame:
+        return pd.read_sql_query(query, con=self.engine, dtype=data_types)  # type: ignore
+
+    def get_latest_block(self) -> int:
+        """
+        Fetches the latest mutually synced block from orderbook databases (with REORG protection)
+        """
+        data_types = {"latest": "int64"}
+        res = self._read_query(open_query("warehouse/latest_block.sql"), data_types)
+        assert len(res) == 1, "Expecting single record"
+        return int(res["latest"][0]) - REORG_THRESHOLD
+
+    def get_internal_imbalances(self, block_range: BlockRange) -> DataFrame:
+        """
+        Fetches and validates Internal Token Imbalances
+        """
+        cow_reward_query = (
+            open_query("warehouse/token_imbalances.sql")
+            .replace("{{start_block}}", str(block_range.block_from))
+            .replace("{{end_block}}", str(block_range.block_to))
+        )
+        data_types = {
+            "block_number": "int64",
+        }
+        return self._read_query(cow_reward_query, data_types)

--- a/src/main.py
+++ b/src/main.py
@@ -9,12 +9,14 @@ from dotenv import load_dotenv
 
 from src.fetch.dune import DuneFetcher
 from src.fetch.orderbook import OrderbookFetcher
+from src.fetch.postgres import PostgresFetcher
 from src.logger import set_log
 from src.models.tables import SyncTable
 from src.post.aws import AWSClient
 from src.sync import sync_app_data
 from src.sync.config import SyncConfig, AppDataSyncConfig
 from src.sync.order_rewards import sync_order_rewards, sync_batch_rewards
+from src.sync.token_imbalance import sync_internal_imbalance
 
 log = set_log(__name__)
 
@@ -80,6 +82,13 @@ if __name__ == "__main__":
             aws,
             config=SyncConfig(volume_path),
             fetcher=OrderbookFetcher(),
+            dry_run=args.dry_run,
+        )
+    elif args.sync_table == SyncTable.INTERNAL_IMBALANCE:
+        sync_internal_imbalance(
+            aws,
+            config=SyncConfig(volume_path),
+            fetcher=PostgresFetcher(os.environ["WAREHOUSE_URL"]),
             dry_run=args.dry_run,
         )
     else:

--- a/src/models/tables.py
+++ b/src/models/tables.py
@@ -8,6 +8,7 @@ class SyncTable(Enum):
     APP_DATA = "app_data"
     ORDER_REWARDS = "order_rewards"
     BATCH_REWARDS = "batch_rewards"
+    INTERNAL_IMBALANCE = "internal_imbalance"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/src/models/token_imbalance_schema.py
+++ b/src/models/token_imbalance_schema.py
@@ -1,0 +1,27 @@
+"""Model for Batch Rewards Data"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pandas import DataFrame
+
+
+@dataclass
+class TokenImbalance:
+    """
+    This class provides a transformation interface (to JSON) for Dataframe
+    """
+
+    @classmethod
+    def from_pdf_to_dune_records(cls, frame: DataFrame) -> list[dict[str, Any]]:
+        """Converts Pandas DataFrame into the expected stream type for Dune"""
+        return [
+            {
+                "block_number": int(row["block_number"]),
+                "tx_hash": row["tx_hash"],
+                "token": row["token"],
+                "amount": int(row["amount"]),
+            }
+            for row in frame.to_dict(orient="records")
+        ]

--- a/src/sql/warehouse/latest_block.sql
+++ b/src/sql/warehouse/latest_block.sql
@@ -1,0 +1,2 @@
+select max(block_number) as latest
+from settlements;

--- a/src/sql/warehouse/token_imbalances.sql
+++ b/src/sql/warehouse/token_imbalances.sql
@@ -1,0 +1,8 @@
+select block_number,
+       concat('0x', encode(s.tx_hash, 'hex')) as tx_hash,
+       concat('0x', encode(token, 'hex'))     as token,
+       amount::text                           as amount
+from internalized_imbalances
+         join settlements s
+              on internalized_imbalances.tx_hash = s.tx_hash
+where block_number > {{start_block}} and block_number <= {{end_block}};

--- a/src/sync/token_imbalance.py
+++ b/src/sync/token_imbalance.py
@@ -1,0 +1,45 @@
+"""Main Entry point for token_imbalance sync"""
+from dune_client.file.interface import FileIO
+
+from src.fetch.postgres import PostgresFetcher
+from src.logger import set_log
+from src.models.block_range import BlockRange
+from src.models.tables import SyncTable
+from src.models.token_imbalance_schema import TokenImbalance
+from src.post.aws import AWSClient
+from src.sync.common import last_sync_block
+from src.sync.config import SyncConfig
+from src.sync.order_rewards import OrderbookDataHandler
+from src.sync.upload_handler import UploadHandler
+
+log = set_log(__name__)
+
+
+def sync_internal_imbalance(
+    aws: AWSClient, fetcher: PostgresFetcher, config: SyncConfig, dry_run: bool
+) -> None:
+    """Token Imbalance Sync Logic"""
+    sync_table = SyncTable.INTERNAL_IMBALANCE
+    block_range = BlockRange(
+        block_from=last_sync_block(
+            aws,
+            table=sync_table,
+            # TODO - determine and set the correct genesis block!
+            genesis_block=17236982,
+        ),
+        block_to=fetcher.get_latest_block(),
+    )
+    # TODO - Gap Detection (find missing txHashes and ensure they are accounted for!)
+    record_handler = OrderbookDataHandler(
+        file_manager=FileIO(config.volume_path / str(sync_table)),
+        block_range=block_range,
+        config=config,
+        data_list=TokenImbalance.from_pdf_to_dune_records(
+            fetcher.get_internal_imbalances(block_range)
+        ),
+        sync_table=sync_table,
+    )
+    UploadHandler(aws, record_handler, table=sync_table).write_and_upload_content(
+        dry_run
+    )
+    log.info(f"{sync_table} sync run completed successfully")

--- a/tests/e2e/test_sync_app_data.py
+++ b/tests/e2e/test_sync_app_data.py
@@ -46,6 +46,7 @@ class TestSyncAppData(IsolatedAsyncioTestCase):
             block_range=block_range_1,
             config=self.config,
             missing_file_name=missing_files,
+            ipfs_access_key=os.environ["IPFS_ACCESS_KEY"],
         )
 
         print(f"Beginning Content Fetching on {len(data_handler.new_rows)} records")

--- a/tests/integration/test_warehouse_fetcher.py
+++ b/tests/integration/test_warehouse_fetcher.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+import pandas as pd
+from dotenv import load_dotenv
+
+from src.fetch.postgres import PostgresFetcher
+from src.models.block_range import BlockRange
+
+
+class TestPostgresWarehouseFetching(unittest.TestCase):
+    def setUp(self) -> None:
+        load_dotenv()
+        # TODO - deploy test DB and populate with some records...
+        self.fetcher = PostgresFetcher(db_url=os.environ["WAREHOUSE_URL"])
+
+    def test_latest_block_reasonable(self):
+        self.assertGreater(self.fetcher.get_latest_block(), 17273090)
+
+    def test_get_imbalances(self):
+        imbalance_df = self.fetcher.get_internal_imbalances(
+            BlockRange(17236982, 17236983)
+        )
+        expected = pd.DataFrame(
+            {
+                "block_number": pd.Series([17236983, 17236983], dtype="int64"),
+                "tx_hash": [
+                    "0x9dc611149c7d6a936554b4be0e4fde455c015a9d5c81650af1433df5e904c791",
+                    "0x9dc611149c7d6a936554b4be0e4fde455c015a9d5c81650af1433df5e904c791",
+                ],
+                "token": [
+                    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                ],
+                "amount": ["-1438513324", "789652004205719637"],
+            },
+        )
+        self.assertIsNone(pd.testing.assert_frame_equal(expected, imbalance_df))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_token_imbalance_schema.py
+++ b/tests/unit/test_token_imbalance_schema.py
@@ -1,0 +1,46 @@
+import unittest
+
+import pandas as pd
+
+from src.models.token_imbalance_schema import TokenImbalance
+
+
+class TestModelTokenImbalance(unittest.TestCase):
+    def test_token_imbalance_schema(self):
+        max_uint = 115792089237316195423570985008687907853269984665640564039457584007913129639936
+        sample_df = pd.DataFrame(
+            {
+                "block_number": pd.Series([123, 456], dtype="int64"),
+                "tx_hash": [
+                    "0x71",
+                    "0x72",
+                ],
+                "token": [
+                    "0xa0",
+                    "0xa1",
+                ],
+                "amount": [9999, max_uint],
+            }
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "amount": 9999,
+                    "block_number": 123,
+                    "token": "0xa0",
+                    "tx_hash": "0x71",
+                },
+                {
+                    "amount": 115792089237316195423570985008687907853269984665640564039457584007913129639936,
+                    "block_number": 456,
+                    "token": "0xa1",
+                    "tx_hash": "0x72",
+                },
+            ],
+            TokenImbalance.from_pdf_to_dune_records(sample_df),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adding `internal_imbalance` sync script, which is basically the same as the orderbook jobs, but reading from a different DB. The query is not overly complicated making a single join to get block numbers.

Note that we wrote a `PostgresFetcher` class to read from this DB (since the OrderbookFetcher reads from two DBs and combines results). More natural approach would be to have a `MultiInstanceDBFetcher` recently introduced in solver-rewards [here](https://github.com/cowprotocol/solver-rewards/pull/200/files#diff-14bc0f308aa5dcfb330f143b5cfe3fe34dd01df48d289adb8b6277d065df3994)

## Test Plan

new tests introduced

- [x] Have already done a full e2e test writing to their staging buckets.
