### PR TITLE
[Slippage] Add genesis_block for internal_imbalances

### DIFF
--- a/src/sync/token_imbalance.py
+++ b/src/sync/token_imbalance.py
@@ -24,8 +24,10 @@ def sync_internal_imbalance(
         block_from=last_sync_block(
             aws,
             table=sync_table,
-            # TODO - determine and set the correct genesis block!
-            genesis_block=17236982,
+            # The first block for which solver competitions
+            # are available in production orderbook:
+            # select * from solver_competitions where id = 1;
+            genesis_block=15173540,
         ),
         block_to=fetcher.get_latest_block(),
     )


### PR DESCRIPTION
The earliest block where we have solver competition data. Goes back to this transaction (July 19, 2022)

https://etherscan.io/tx/0x044499c2a830890cb0a8ecf9aec6c5621e8310092a58d369cdef726254d3d108

Found via the following query on the production orderbook

```sql
select * from solver_competitions where id = 1;
```