### PR TITLE
Use String for Large Numbers

### DIFF
--- a/src/models/token_imbalance_schema.py
+++ b/src/models/token_imbalance_schema.py
@@ -21,7 +21,7 @@ class TokenImbalance:
                 "block_number": int(row["block_number"]),
                 "tx_hash": row["tx_hash"],
                 "token": row["token"],
-                "amount": int(row["amount"]),
+                "amount": str(row["amount"]),
             }
             for row in frame.to_dict(orient="records")
         ]

--- a/tests/unit/test_token_imbalance_schema.py
+++ b/tests/unit/test_token_imbalance_schema.py
@@ -19,20 +19,20 @@ class TestModelTokenImbalance(unittest.TestCase):
                     "0xa0",
                     "0xa1",
                 ],
-                "amount": [9999, max_uint],
+                "amount": [-9999, max_uint],
             }
         )
 
         self.assertEqual(
             [
                 {
-                    "amount": 9999,
+                    "amount": "-9999",
                     "block_number": 123,
                     "token": "0xa0",
                     "tx_hash": "0x71",
                 },
                 {
-                    "amount": 115792089237316195423570985008687907853269984665640564039457584007913129639936,
+                    "amount": "115792089237316195423570985008687907853269984665640564039457584007913129639936",
                     "block_number": 456,
                     "token": "0xa1",
                     "tx_hash": "0x72",


### PR DESCRIPTION
We had an issue with type inference on Dune side. We don't want our large integers being cast to Decimal so we use string.