### PR TITLE
Reduce log message to dict keys instead

### DIFF
--- a/src/post/aws.py
+++ b/src/post/aws.py
@@ -82,7 +82,7 @@ class BucketStructure:
                 # Catches any unrecognized filepath.
                 log.warning(f"Found unexpected file {object_key}")
 
-        log.debug(f"loaded bucket filesystem: {grouped_files}")
+        log.debug(f"loaded bucket filesystem: {grouped_files.keys()}")
 
         return cls(files=grouped_files)
 

--- a/tests/integration/test_aws.py
+++ b/tests/integration/test_aws.py
@@ -35,7 +35,7 @@ class TestAWSConnection(unittest.TestCase):
         s3_resource = self.aws_client._assume_role()
         self.assertIsNotNone(s3_resource.buckets)
 
-    def create_upload_remove(self):
+    def test_create_upload_remove(self):
         Path(self.empty_file).touch()
         self.aws_client.upload_file(
             filename=self.empty_file,
@@ -130,7 +130,6 @@ class TestAWSConnection(unittest.TestCase):
             os.remove(Path(block_indexed_filename))
 
         self.assertEqual(n, len(aws.existing_files().get(table)))
-
         aws.delete_all(table)
         self.assertEqual([], aws.existing_files().get(table))
 


### PR DESCRIPTION
These logs were getting out of control (too many files being printed). WE reduce the log to just the dict keys (which does not grow).