### PR TITLE
[AppData] Support for New Format

### DIFF
--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -49,9 +49,6 @@ class OrderbookFetcher:
     def _read_query_for_env(
         cls, query: str, env: OrderbookEnv, data_types: Optional[dict[str, str]] = None
     ) -> DataFrame:
-        # It seems there is a bug in mypy on the dtype field (with error [arg-type]).
-        # They expect types that should align with what we pass.
-        # More context at: https://github.com/cowprotocol/dune-sync/issues/24
         return pd.read_sql_query(query, con=cls._pg_engine(env), dtype=data_types)
 
     @classmethod

--- a/tests/unit/test_ipfs.py
+++ b/tests/unit/test_ipfs.py
@@ -15,7 +15,7 @@ class TestIPFS(unittest.TestCase):
         self.assertEqual(
             "bafybeib5q5w6r7gxbfutjhes24y65mcif7ugm7hmub2vsk4hqueb2yylti",
             str(
-                Cid(
+                Cid.old_schema(
                     "0x3d876de8fcd70969349c92d731eeb0482fe8667ceca075592b8785081d630b9a"
                 )
             ),
@@ -23,8 +23,18 @@ class TestIPFS(unittest.TestCase):
         self.assertEqual(
             "bafybeia747cvkwz7tqkp67da3ehrl4nfwena3jnr5cvainmcugzocbmnbq",
             str(
-                Cid(
+                Cid.old_schema(
                     "0x1FE7C5555B3F9C14FF7C60D90F15F1A5B11A0DA5B1E8AA043582A1B2E1058D0C"
+                )
+            ),
+        )
+
+    def test_new_hash_to_cid(self):
+        self.assertEqual(
+            "bafkrwiek6tumtfzvo6yivqq5c7jtdkw6q3ar5pgfcjdujvrbzkbwl3eueq",
+            str(
+                Cid(
+                    "0x8af4e8c9973577b08ac21d17d331aade86c11ebcc5124744d621ca8365ec9424"
                 )
             ),
         )
@@ -54,7 +64,7 @@ class TestIPFS(unittest.TestCase):
                     }
                 },
             },
-            Cid(
+            Cid.old_schema(
                 "3d876de8fcd70969349c92d731eeb0482fe8667ceca075592b8785081d630b9a"
             ).get_content(ACCESS_KEY, max_retries=10),
         )
@@ -71,7 +81,7 @@ class TestIPFS(unittest.TestCase):
                     }
                 },
             },
-            Cid(
+            Cid.old_schema(
                 "1FE7C5555B3F9C14FF7C60D90F15F1A5B11A0DA5B1E8AA043582A1B2E1058D0C"
             ).get_content(ACCESS_KEY),
         )


### PR DESCRIPTION
This change extends the Cid class to support arbitrary prefixes and explicitly makes use of both the OLD and NEW format that we use in https://github.com/cowprotocol/services. 

Because we will need to support both for eternity, the app content fetching is reworked in a way that prioritizes the new format and only attempts the old format when the new one is unavailable.

I believe that we could completely remove support for the old format if all the existing files were migrated to the corresponding CIDs (i.e. those constructed with the new format) -- cc @vkgnosis is this something we plan to do? If we did this, then the changes to be made here would be only a one line change of prefix.

Note this is based on (and blocked by #45)
