### PR TITLE
Rework async content fetching

### DIFF
--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -49,9 +49,6 @@ class OrderbookFetcher:
     def _read_query_for_env(
         cls, query: str, env: OrderbookEnv, data_types: Optional[dict[str, str]] = None
     ) -> DataFrame:
-        # It seems there is a bug in mypy on the dtype field (with error [arg-type]).
-        # They expect types that should align with what we pass.
-        # More context at: https://github.com/cowprotocol/dune-sync/issues/24
         return pd.read_sql_query(query, con=cls._pg_engine(env), dtype=data_types)
 
     @classmethod


### PR DESCRIPTION
In order to make the diff in https://github.com/cowprotocol/dune-sync/pull/44 easier to digest, we do a small refactoring before. 

We break async content fetching into two methods.