### PR TITLE
[AWS] Get Credentials from Session

### DIFF
--- a/src/post/aws.py
+++ b/src/post/aws.py
@@ -138,16 +138,13 @@ class AWSClient:
                 RoleSessionName="InternalSession",
             )
             credentials = internal_assumed_role_object["Credentials"]
-        else:
-            # When deployed to AWS and
-            credentials = sts_client.get_session_token()["Credentials"]
 
-        sts_client = boto3.client(
-            "sts",
-            aws_access_key_id=credentials["AccessKeyId"],
-            aws_secret_access_key=credentials["SecretAccessKey"],
-            aws_session_token=credentials["SessionToken"],
-        )
+            sts_client = boto3.client(
+                "sts",
+                aws_access_key_id=credentials["AccessKeyId"],
+                aws_secret_access_key=credentials["SecretAccessKey"],
+                aws_session_token=credentials["SessionToken"],
+            )
 
         external_assumed_role_object = sts_client.assume_role(
             RoleArn=self.external_role,

--- a/src/post/aws.py
+++ b/src/post/aws.py
@@ -132,14 +132,14 @@ class AWSClient:
         """
         sts_client = boto3.client("sts")
 
-        try:
+        if "AWS_SECRET_ACCESS_KEY" in os.environ:
             # When credentials are supplied directly in the environment (local testing)
             internal_assumed_role_object = sts_client.assume_role(
                 RoleArn=self.internal_role,
                 RoleSessionName="InternalSession",
             )
             credentials = internal_assumed_role_object["Credentials"]
-        except ClientError:
+        else:
             # When deployed to AWS and
             credentials = sts_client.get_session_token()["Credentials"]
 

--- a/src/post/aws.py
+++ b/src/post/aws.py
@@ -10,7 +10,6 @@ import boto3
 from boto3.resources.base import ServiceResource
 from boto3.s3.transfer import S3Transfer
 from botocore.client import BaseClient
-from botocore.exceptions import ClientError
 from dotenv import load_dotenv
 
 from src.logger import set_log


### PR DESCRIPTION
In an effort to supply fewer env vars to our pods, when the image is deployed on AWS, certain session tokens for obtaining credentials are already injected into the runtime environment. 

FYI (@cowprotocol/analytics)
This is an experimental PR made in collaboration with @mateipopa from devops that will be reverted if it does not work out. Alternatively we could deploy a beta version based on this branch and test that out in staging before even merging.


