### PR TITLE
Fetch appdata from backend

### DIFF
--- a/src/fetch/ipfs.py
+++ b/src/fetch/ipfs.py
@@ -39,21 +39,14 @@ class Cid:
     ) -> FoundContent | NotFoundContent:
         """Fetches the given app data hash from the cow protocol backend (prod and staging)"""
 
-        # first try prod
-        url = f"https://api.cow.fi/mainnet/api/v1/app_data/{hex_str}"
-        response = cls.fetch_from_backend_inner(
-            url, hex_str, first_seen_block, attempts
-        )
-        if response:
-            return response
-
-        # then try barn
-        url = f"https://barn.api.cow.fi/mainnet/api/v1/app_data/{hex_str}"
-        response = cls.fetch_from_backend_inner(
-            url, hex_str, first_seen_block, attempts
-        )
-        if response:
-            return response
+        envs = ["api", "barn.api"]
+        for env in envs:
+            url = f"https://{env}.cow.fi/mainnet/api/v1/app_data/{hex_str}"
+            response = cls.fetch_from_backend_inner(
+                url, hex_str, first_seen_block, attempts
+            )
+            if response:
+                return response
 
         return NotFoundContent(hex_str, first_seen_block, attempts + 1)
 

--- a/src/fetch/ipfs.py
+++ b/src/fetch/ipfs.py
@@ -33,6 +33,47 @@ class Cid:
         """Constructor of old CID format (with different prefix)"""
         return cls(hex_str, OLD_PREFIX)
 
+    @classmethod
+    def fetch_from_backend(
+        cls, hex_str: str, first_seen_block: int, attempts: int
+    ) -> FoundContent | NotFoundContent:
+        """Fetches the given app data hash from the cow protocol backend (prod and staging)"""
+
+        # first try prod
+        url = f"https://api.cow.fi/mainnet/api/v1/app_data/{hex_str}"
+        response = cls.fetch_from_backend_inner(
+            url, hex_str, first_seen_block, attempts
+        )
+        if response:
+            return response
+
+        # then try barn
+        url = f"https://barn.api.cow.fi/mainnet/api/v1/app_data/{hex_str}"
+        response = cls.fetch_from_backend_inner(
+            url, hex_str, first_seen_block, attempts
+        )
+        if response:
+            return response
+
+        return NotFoundContent(hex_str, first_seen_block, attempts + 1)
+
+    @classmethod
+    def fetch_from_backend_inner(
+        cls, url: str, hex_str: str, first_seen_block: int, attempts: int
+    ) -> Optional[FoundContent]:
+        """Fetches the given app data hash from the specified backend url"""
+        response = requests.get(url, timeout=1)
+        if response.status_code != 200:
+            return None
+
+        if attempts:
+            log.debug(f"Found previously missing content hash {hex_str} in the backend")
+        else:
+            log.debug(
+                f"Found content for {hex_str} in the backend ({attempts + 1} trys)"
+            )
+        return FoundContent(hex_str, first_seen_block, response.json())
+
     @property
     def hex(self) -> str:
         """Returns hex representation"""
@@ -90,13 +131,21 @@ class Cid:
                 cid = cls(app_hash)
 
                 first_seen_block = int(row["first_seen_block"])
+                # try fetching new format from IPFS
                 result = await cid.fetch_content(
                     max_retries, previous_attempts, session, first_seen_block
                 )
+
                 if isinstance(result, NotFoundContent):
-                    # Try Fetching the old format
+                    # try fetching the old format from IPFS
                     result = await cls.old_schema(app_hash).fetch_content(
                         max_retries, previous_attempts, session, first_seen_block
+                    )
+
+                if isinstance(result, NotFoundContent):
+                    # try fetching any format from backend (prod and staging)
+                    result = cls.fetch_from_backend(
+                        app_hash, first_seen_block, previous_attempts
                     )
 
                 if isinstance(result, FoundContent):

--- a/tests/unit/test_ipfs.py
+++ b/tests/unit/test_ipfs.py
@@ -5,6 +5,7 @@ from unittest import IsolatedAsyncioTestCase
 from dotenv import load_dotenv
 
 from src.fetch.ipfs import Cid
+from src.models.app_data_content import FoundContent
 
 load_dotenv()
 ACCESS_KEY = os.environ["IPFS_ACCESS_KEY"]
@@ -84,6 +85,69 @@ class TestIPFS(unittest.TestCase):
             Cid.old_schema(
                 "1FE7C5555B3F9C14FF7C60D90F15F1A5B11A0DA5B1E8AA043582A1B2E1058D0C"
             ).get_content(ACCESS_KEY),
+        )
+
+    def test_get_content_from_backend(self):
+        # only exists on prod
+        self.assertEqual(
+            FoundContent(
+                app_hash="008f7a676ab1284ba638d777c3ec36a1aadd4d5b794604a79bda78d5509f134d",
+                first_seen_block=0,
+                content={
+                    "appCode": "CoW Swap-SafeApp",
+                    "environment": "production",
+                    "metadata": {
+                        "quote": {"slippageBips": "30", "version": "0.2.0"},
+                        "orderClass": {"orderClass": "market", "version": "0.1.0"},
+                    },
+                    "version": "0.6.0",
+                },
+            ),
+            Cid.fetch_from_backend(
+                "008f7a676ab1284ba638d777c3ec36a1aadd4d5b794604a79bda78d5509f134d", 0, 0
+            ),
+        )
+
+        # only exists on barn
+        self.assertEqual(
+            FoundContent(
+                app_hash="080469552d19a60b9aef6418c564176ec099bd049c78bffa5cda51d5b0f539f8",
+                first_seen_block=0,
+                content={
+                    "appCode": "CoW Swap",
+                    "environment": "barn",
+                    "metadata": {
+                        "quote": {"slippageBips": "100", "version": "0.2.0"},
+                        "orderClass": {"orderClass": "market", "version": "0.1.0"},
+                    },
+                    "version": "0.5.0",
+                },
+            ),
+            Cid.fetch_from_backend(
+                "080469552d19a60b9aef6418c564176ec099bd049c78bffa5cda51d5b0f539f8", 0, 0
+            ),
+        )
+
+        # also works with 0x prefixed string
+        self.assertEqual(
+            FoundContent(
+                app_hash="0x080469552d19a60b9aef6418c564176ec099bd049c78bffa5cda51d5b0f539f8",
+                first_seen_block=0,
+                content={
+                    "appCode": "CoW Swap",
+                    "environment": "barn",
+                    "metadata": {
+                        "quote": {"slippageBips": "100", "version": "0.2.0"},
+                        "orderClass": {"orderClass": "market", "version": "0.1.0"},
+                    },
+                    "version": "0.5.0",
+                },
+            ),
+            Cid.fetch_from_backend(
+                "0x080469552d19a60b9aef6418c564176ec099bd049c78bffa5cda51d5b0f539f8",
+                0,
+                0,
+            ),
         )
 
 


### PR DESCRIPTION
It's possible that in the future some app data content will only be available in the cow protocol backend.
To make the app data indexing work properly in those cases we need to add another fallback to app data fetching.
The new order is:
1. try new format on IPFS
2. try old format on IPFS
3. try any format on the prod backend
4. try any format on the staging backend

### Tests
* unit test that verifies that content that `fetch_from_backend()` is able to find content that only exists on prod or only exists on prod
* unit test that verifies that hex strings with or without `0x` prefix
* a unit test that verifies that `fetch_many()` is able to fetch app data that only exists in the backend was not possible at the time because such data didn't exist yet