### PR TITLE
Check for appdata in the backend first

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-dune-client=0.3.0
+dune-client==0.3.0
 psycopg2-binary>=2.9.3
 python-dotenv>=0.20.0
 requests>=2.28.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-dune-client>=0.3.0
+dune-client=0.3.0
 psycopg2-binary>=2.9.3
 python-dotenv>=0.20.0
 requests>=2.28.1

--- a/src/fetch/ipfs.py
+++ b/src/fetch/ipfs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Optional
 
+import json
 import aiohttp
 import requests
 from aiohttp import ClientSession
@@ -65,7 +66,8 @@ class Cid:
             log.debug(
                 f"Found content for {hex_str} in the backend ({attempts + 1} trys)"
             )
-        return FoundContent(hex_str, first_seen_block, response.json()["fullAppData"])
+        app_data_string = response.json()["fullAppData"]
+        return FoundContent(hex_str, first_seen_block, json.loads(app_data_string))
 
     @property
     def hex(self) -> str:

--- a/src/fetch/ipfs.py
+++ b/src/fetch/ipfs.py
@@ -129,7 +129,6 @@ class Cid:
                     app_hash, first_seen_block, previous_attempts
                 )
 
-
                 if isinstance(result, NotFoundContent):
                     # try fetching new format from IPFS
                     result = await cid.fetch_content(

--- a/src/fetch/ipfs.py
+++ b/src/fetch/ipfs.py
@@ -65,7 +65,7 @@ class Cid:
             log.debug(
                 f"Found content for {hex_str} in the backend ({attempts + 1} trys)"
             )
-        return FoundContent(hex_str, first_seen_block, response.json())
+        return FoundContent(hex_str, first_seen_block, response.json()["fullAppData"])
 
     @property
     def hex(self) -> str:

--- a/src/fetch/ipfs.py
+++ b/src/fetch/ipfs.py
@@ -124,21 +124,22 @@ class Cid:
                 cid = cls(app_hash)
 
                 first_seen_block = int(row["first_seen_block"])
-                # try fetching new format from IPFS
-                result = await cid.fetch_content(
-                    max_retries, previous_attempts, session, first_seen_block
+                # try fetching any format from backend (prod and staging)
+                result = cls.fetch_from_backend(
+                    app_hash, first_seen_block, previous_attempts
                 )
+
+
+                if isinstance(result, NotFoundContent):
+                    # try fetching new format from IPFS
+                    result = await cid.fetch_content(
+                        max_retries, previous_attempts, session, first_seen_block
+                    )
 
                 if isinstance(result, NotFoundContent):
                     # try fetching the old format from IPFS
                     result = await cls.old_schema(app_hash).fetch_content(
                         max_retries, previous_attempts, session, first_seen_block
-                    )
-
-                if isinstance(result, NotFoundContent):
-                    # try fetching any format from backend (prod and staging)
-                    result = cls.fetch_from_backend(
-                        app_hash, first_seen_block, previous_attempts
                     )
 
                 if isinstance(result, FoundContent):


### PR DESCRIPTION
We are currently wasting our pinata credits because we first try to repeatedly fetch the appdata from IPFS when we are currently not even uploading that to IPFS.
Instead we should always try to fetch from our backend first because that's basically free and should have all the useful appdata (nonsense values are not stored there).