### PR TITLE
Restrict orders which receive quote rewards

### DIFF
--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -25,7 +25,10 @@ with trade_hashes as (SELECT settlement.solver,
                         FROM trades t
                                INNER JOIN orders o ON order_uid = uid
                                JOIN order_quotes oq ON t.order_uid = oq.order_uid
-                        WHERE block_number > {{start_block}}
+                        WHERE ((o.kind = 'sell' AND o.buy_amount <= oq.buy_amount)
+                            OR (o.kind='buy' AND o.sell_amount >= oq.sell_amount))
+                          AND o.partially_fillable='f'
+                          AND block_number > {{start_block}}
                           AND block_number <= {{end_block}}
                           AND oq.solver != '\x0000000000000000000000000000000000000000')
 


### PR DESCRIPTION
We decided to restrict a bit more quotes which can receive rewards to be in line with the original spirit of CIP-27.

This PR would make the data synced to dune consistent with https://github.com/cowprotocol/solver-rewards/pull/328

The additional restrictions are:
- only orders where the amounts are below quoted amounts are eligible
- only orders which are not partially fillable are eligible

Note that the convention for block ranges in this repo is different from the convention in the solver rewards repo. This inconsistency is maybe a bit confusing. But not a problem for any of the queries since this repo is only about syncing data.