### PR TITLE
Fix query that computes quoter and syncs data on Dune

### DIFF
--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -45,4 +45,4 @@ from trade_hashes
                        on trade_hashes.order_uid = o.order_uid
                          and trade_hashes.auction_id = o.auction_id
       left outer join winning_quotes wq
-            on o.order_uid = wq.order_uid;
+            on trade_hashes.order_uid = wq.order_uid;


### PR DESCRIPTION
This PR addresses issue #62, which was caused by a change in our database. Specifically, the `order_execution` table now only contains entries for limit orders (and NOT market orders).