### PR TITLE
Fix pandas version to 2.1.4

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,7 +2,7 @@ dune-client==0.3.0
 psycopg2-binary>=2.9.3
 python-dotenv>=0.20.0
 requests>=2.28.1
-pandas>=1.5.0
+pandas==2.1.4
 ndjson>=0.3.1
 py-multiformats-cid>=0.4.4
 boto3>=1.26.12


### PR DESCRIPTION
Fix pandas version to 2.1.4 circumvent a `AttributeError: 'Engine' object has no attribute 'cursor'` when querying databases.