### PR TITLE
Fix volume cap for protocol fees

### DIFF
--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -96,7 +96,7 @@ order_surplus AS (
                                         THEN fp.surplus_factor / (1 - fp.surplus_factor) * surplus
                                     ELSE
                                         LEAST(
-                                            fp.max_volume_factor / (1 - fp.max_volume_factor) * os.buy_amount, -- at most charge a fraction of volume
+                                            fp.max_volume_factor * os.sell_amount * os.buy_amount / (os.sell_amount - os.observed_fee), -- at most charge a fraction of volume
                                             fp.surplus_factor / (1 - fp.surplus_factor) * surplus -- charge a fraction of surplus
                                         )
                                 END

--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -80,7 +80,7 @@ order_surplus AS (
                                         THEN fp.surplus_factor / (1 - fp.surplus_factor) * surplus
                                     ELSE
                                         LEAST(
-                                            fp.max_volume_factor / (1 - fp.max_volume_factor) * os.buy_amount, -- at most charge a fraction of volume
+                                            fp.max_volume_factor * os.sell_amount * os.buy_amount / (os.sell_amount - os.observed_fee), -- at most charge a fraction of volume
                                             fp.surplus_factor / (1 - fp.surplus_factor) * surplus -- charge a fraction of surplus
                                         )
                                 END


### PR DESCRIPTION
The cap for volume fees in the current code is based on the assumption that the protocol fee on surplus for sell orders is a fraction of the amount received by the user, i.e., a fraction of the total buy amount. The implementation in the driver is based on the cap being a fraction of the amount sent by the user, i.e., a fraction of the total sell amount. This resulted in an issue due to fees in sell tokens being implicitly converted to buy tokens via the uniform clearing price and not using effective directional prices.

This PR changes the cap to be consistent with the current driver implementation.

This requires re-syncing data to dune.

The code should be changed back in combination with a fix to the driver for rank by surplus since the concept of observed fee has no meaning there.