### PR TITLE
[Hotfix] Update latest block query

### DIFF
--- a/src/sql/orderbook/latest_block.sql
+++ b/src/sql/orderbook/latest_block.sql
@@ -1,3 +1,2 @@
-select min(block_number) latest
-from settlements
-where tx_from is null;
+select max(block_number) latest
+from settlement_observations;


### PR DESCRIPTION
Dune uploads are broken at the moment due to a change to the `settlements` table in our database. This PR changes the query to be compatible with that change.

Instead of looking at the earliest block without some transaction data in the `settlements` table we now look at the latest block in the `settlement_observations` table.

This should work with both the new and old format of the settlements table.

Tests passed locally.