### PR TITLE
In-market classification for fill-or-kill limit orders

### DIFF
--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -115,9 +115,9 @@ order_surplus AS (
                         FROM trades t
                                INNER JOIN orders o ON order_uid = uid
                                JOIN order_quotes oq ON t.order_uid = oq.order_uid
-                        WHERE ((o.kind = 'sell' AND o.buy_amount <= oq.buy_amount)
-                            OR (o.kind='buy' AND o.sell_amount >= oq.sell_amount))
-                          AND o.partially_fillable='f'
+                        WHERE ((o.kind = 'sell' AND (oq.sell_amount - oq.gas_amount * oq.gas_price / oq.sell_token_price) * oq.buy_amount >= o.buy_amount *  oq.sell_amount)
+                            OR (o.kind='buy' AND o.sell_amount >= oq.sell_amount + oq.gas_amount * oq.gas_price / oq.sell_token_price))
+                          AND o.partially_fillable='f' -- the code above might fail for partially fillable orders
                           AND block_number > {{start_block}}
                           AND block_number <= {{end_block}}
                           AND oq.solver != '\x0000000000000000000000000000000000000000')

--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -115,7 +115,8 @@ order_surplus AS (
                         FROM trades t
                                INNER JOIN orders o ON order_uid = uid
                                JOIN order_quotes oq ON t.order_uid = oq.order_uid
-                        WHERE ((o.kind = 'sell' AND (oq.sell_amount - oq.gas_amount * oq.gas_price / oq.sell_token_price) * oq.buy_amount >= o.buy_amount *  oq.sell_amount)
+                        WHERE (o.class = 'market'
+                            OR (o.kind = 'sell' AND (oq.sell_amount - oq.gas_amount * oq.gas_price / oq.sell_token_price) * oq.buy_amount >= o.buy_amount *  oq.sell_amount)
                             OR (o.kind='buy' AND o.sell_amount >= oq.sell_amount + oq.gas_amount * oq.gas_price / oq.sell_token_price))
                           AND o.partially_fillable='f' -- the code above might fail for partially fillable orders
                           AND block_number > {{start_block}}


### PR DESCRIPTION
We currently classify limit orders as in-market based on quoted amounts, see #61. As it turns out, those amounts do not take fees into account for limit orders. Therefore we misclassify some orders whicch are out-of-market as in-market.

This PR changes the classification of in-market orders to be in line with how market orders are created in the frontend: If the quoted amounts are `oq.sell_amount` and `oq.buy_amount` and the estimated fee is `oq.gas_amount * oq.gas_price / oq.sell_price` then a market order sell order would have charged a fee of `oq.gas_amount * oq.gas_price / oq.sell_price` and exchanged the remaining abount `oq.sell_amount - oq.gas_amount * oq.gas_price / oq.sell_price` at the quoted exchange rate `oq.buy_amount / oq.sell_amount` to a buy amount of `(oq.sell_amount - oq.gas_amount * oq.gas_price / oq.sell_price) / oq.sell_amount * oq.buy_amount`. Thus an order would be in-market if `o.buy_amount <= (oq.sell_amount - oq.gas_amount * oq.gas_price / oq.sell_price) / oq.sell_amount * oq.buy_amount`, whoch is equivalent to `(oq.sell_amount - oq.gas_amount * oq.gas_price / oq.sell_token_price) * oq.buy_amount >= o.buy_amount *  oq.sell_amount`.

For a buy order a reasonable market order would have traded `oq.sell_amount + oq.gas_amount * oq.gas_price / oq.sell_token_price` to `oq.buy_amount`. Thus an order is regarded as in-market if `o.sell_amount >= oq.sell_amount + oq.gas_amount * oq.gas_price / oq.sell_token_price`.

These rules are implemented in this PR.

Note that those rules are not really applicable to paartially-fillable orders. It can happen that an execution for the full amount is not possible (out-of-market) but smaller chunks can be executed.  When that usecase arises we need to revisit this code.