### PR TITLE
Pin black version

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 -r prod.txt
 pandas-stubs>=1.5.1.221024
 boto3-stubs>=1.26.12
-black>=22.6.0
+black==23.12.0
 mypy==1.3.0
 mypy-extensions==1.0.0
 pylint>=2.14.4


### PR DESCRIPTION
Currently some PRs are failing tests due to black errors. Since there was a new release a few days ago, pinning the version of black might fix them for now.