### PR TITLE
make volume fee code identical to code in solver-rewards repo

### DIFF
--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -97,7 +97,7 @@ order_surplus AS (
                                 )
                     END
             WHEN fp.kind = 'volume'
-                THEN fp.volume_factor / (1 - fp.volume_factor) * os.sell_amount
+                THEN fp.volume_factor / (1 + fp.volume_factor) * os.sell_amount
         END AS protocol_fee,
         CASE
             WHEN fp.kind = 'surplus'


### PR DESCRIPTION
This code change makes the code to compute volume based protocol fees
identical to the code in the solver-rewards repo.

Potentially the implementation is not consistent to what will be done in
the driver. Since volume based fees are not used in production yet this is
not much of an issue for now.

I am also not super sure if we might need different cases for sell and buy orders.
In any case, since we only test those queries in the solver rewards repo
we should make the code consitsant with said repo.