### PR TITLE
use more optimistic block range for sync

### DIFF
--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -15,7 +15,7 @@ from sqlalchemy.engine import Engine
 from src.models.block_range import BlockRange
 from src.utils import open_query
 
-REORG_THRESHOLD = 65
+MAX_PROCESSING_DELAY = 1
 
 
 class OrderbookEnv(Enum):
@@ -69,7 +69,7 @@ class OrderbookFetcher:
             open_query("orderbook/latest_block.sql"), data_types
         )
         assert len(barn) == 1 == len(prod), "Expecting single record"
-        return min(int(barn["latest"][0]), int(prod["latest"][0])) - REORG_THRESHOLD
+        return max(int(barn["latest"][0]), int(prod["latest"][0])) - MAX_PROCESSING_DELAY
 
     @classmethod
     def get_order_rewards(cls, block_range: BlockRange) -> DataFrame:

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -69,7 +69,9 @@ class OrderbookFetcher:
             open_query("orderbook/latest_block.sql"), data_types
         )
         assert len(barn) == 1 == len(prod), "Expecting single record"
-        return max(int(barn["latest"][0]), int(prod["latest"][0])) - MAX_PROCESSING_DELAY
+        return (
+            max(int(barn["latest"][0]), int(prod["latest"][0])) - MAX_PROCESSING_DELAY
+        )
 
     @classmethod
     def get_order_rewards(cls, block_range: BlockRange) -> DataFrame:

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -15,7 +15,7 @@ from sqlalchemy.engine import Engine
 from src.models.block_range import BlockRange
 from src.utils import open_query
 
-MAX_PROCESSING_DELAY = 1
+MAX_PROCESSING_DELAY = 10
 
 
 class OrderbookEnv(Enum):

--- a/src/fetch/postgres.py
+++ b/src/fetch/postgres.py
@@ -7,10 +7,10 @@ from pandas import DataFrame
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
-from src.fetch.orderbook import REORG_THRESHOLD
 from src.models.block_range import BlockRange
 from src.utils import open_query
 
+REORG_THRESHOLD = 65
 
 @dataclass
 class PostgresFetcher:

--- a/src/fetch/postgres.py
+++ b/src/fetch/postgres.py
@@ -12,6 +12,7 @@ from src.utils import open_query
 
 REORG_THRESHOLD = 65
 
+
 @dataclass
 class PostgresFetcher:
     """


### PR DESCRIPTION
This PR addresses issue #72. At the moment the block range is computed using the minimum of the latest finalized block from production and
staging and subtracting `REORG_THRESHOLD = 65`. This was done as a hot fix in #71. One problem with this approach is that having few settlements in staging blocks upload of production data to dune.

This PR changes the behavior to look at the maximum block of the latest finalized blocks from production and staging subtracting
`MAX_PROCESSING_DELAY = 1`. This should leave enough time for the autopilot to process settlements after finalization in staging and production.

For testing we should monitor if there are settlements with missing information on dune compared to our database.