### PR TITLE
Add MATERIALIZED to orderbook queries

### DIFF
--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -1,4 +1,4 @@
-WITH observed_settlements AS (SELECT
+WITH observed_settlements AS MATERIALIZED (SELECT
                                 -- settlement
                                 tx_hash,
                                 solver,
@@ -17,7 +17,7 @@ WITH observed_settlements AS (SELECT
                               WHERE ss.block_deadline > {{start_block}}
                                 AND ss.block_deadline <= {{end_block}}),
 
-     auction_participation as (SELECT ss.auction_id,
+     auction_participation as MATERIALIZED (SELECT ss.auction_id,
                                       array_agg(
                                               concat('0x', encode(participant, 'hex')) ORDER BY participant
                                         ) as participating_solvers
@@ -132,7 +132,7 @@ order_surplus AS (
     JOIN auction_prices ap_protocol -- contains price: protocol fee token
         ON opf.auction_id = ap_protocol.auction_id AND opf.protocol_fee_token = ap_protocol.token
 ),
-batch_protocol_fees AS (
+batch_protocol_fees AS MATERIALIZED (
     SELECT
         solver,
         tx_hash,

--- a/src/sql/orderbook/order_rewards.sql
+++ b/src/sql/orderbook/order_rewards.sql
@@ -1,4 +1,4 @@
-with trade_hashes as (
+with trade_hashes as MATERIALIZED (
     SELECT settlement.solver,
             t.block_number as block_number,
             order_uid,
@@ -96,7 +96,7 @@ order_surplus AS (
     JOIN fee_policies fp -- contains protocol fee policy
         ON os.auction_id = fp.auction_id AND os.order_uid = fp.order_uid
 )
-,order_protocol_fee_prices AS (
+,order_protocol_fee_prices AS MATERIALIZED (
     SELECT
         opf.order_uid,
         opf.auction_id,
@@ -107,7 +107,7 @@ order_surplus AS (
     JOIN auction_prices ap-- contains price: protocol fee token
         ON opf.auction_id = ap.auction_id AND opf.protocol_fee_token = ap.token
 ),
-winning_quotes as (
+winning_quotes as MATERIALIZED (
     SELECT concat('0x', encode(oq.solver, 'hex')) as quote_solver,
             oq.order_uid
     FROM trades t


### PR DESCRIPTION
This PR addresses a performance bug in dune-sync orderbook queries.  See https://github.com/cowprotocol/solver-rewards/pull/337 for an explanation.  The problem in dune-sync is not as bad since block ranges are generally smaller than for weekly solver rewards.

The main difference of this PR to https://github.com/cowprotocol/solver-rewards/pull/337 is that the performance bug is present in two queries. Both were sprinkeled with `MATERIALIZED`.

It should be merged only it the other repo is merged. Hopefully it is merged before the next time we need to resync a week of data to dune.