### PR TITLE
Implement CIP-36

### DIFF
--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -99,8 +99,12 @@ class OrderbookFetcher:
             open_query("orderbook/batch_rewards.sql")
             .replace("{{start_block}}", str(block_range.block_from))
             .replace("{{end_block}}", str(block_range.block_to))
-            .replace("{{EPSILON_LOWER}}", "10000000000000000")  # lower ETH cap for payment (in WEI)
-            .replace("{{EPSILON_UPPER}}", "12000000000000000")  # upper ETH cap for payment (in WEI)
+            .replace(
+                "{{EPSILON_LOWER}}", "10000000000000000"
+            )  # lower ETH cap for payment (in WEI)
+            .replace(
+                "{{EPSILON_UPPER}}", "12000000000000000"
+            )  # upper ETH cap for payment (in WEI)
         )
         data_types = {
             # According to this: https://stackoverflow.com/a/11548224

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -99,7 +99,8 @@ class OrderbookFetcher:
             open_query("orderbook/batch_rewards.sql")
             .replace("{{start_block}}", str(block_range.block_from))
             .replace("{{end_block}}", str(block_range.block_to))
-            .replace("{{EPSILON}}", "10000000000000000")  # ETH cap for payment (in WEI)
+            .replace("{{EPSILON_LOWER}}", "10000000000000000")  # lower ETH cap for payment (in WEI)
+            .replace("{{EPSILON_UPPER}}", "12000000000000000")  # upper ETH cap for payment (in WEI)
         )
         data_types = {
             # According to this: https://stackoverflow.com/a/11548224

--- a/src/sql/orderbook/batch_rewards.sql
+++ b/src/sql/orderbook/batch_rewards.sql
@@ -189,8 +189,8 @@ batch_protocol_fees AS (
                                    fee - network_fee_correction as network_fee,-- the network fee
                                    surplus + protocol_fee + fee - network_fee_correction - reference_score as uncapped_payment_eth,
                                    -- Uncapped Reward = CLAMP_[-E, E + exec_cost](uncapped_reward_eth)
-                                   LEAST(GREATEST(-{{EPSILON}}, surplus + protocol_fee + fee - network_fee_correction - reference_score),
-                                     {{EPSILON}} + execution_cost) as capped_payment,
+                                   LEAST(GREATEST(-{{EPSILON_LOWER}}, surplus + protocol_fee + fee - network_fee_correction - reference_score),
+                                     {{EPSILON_UPPER}} + execution_cost) as capped_payment,
                                    winning_score,
                                    reference_score,
                                    participating_solvers           as participating_solvers

--- a/tests/integration/test_fetch_orderbook.py
+++ b/tests/integration/test_fetch_orderbook.py
@@ -8,188 +8,248 @@ from src.models.block_range import BlockRange
 
 class TestFetchOrderbook(unittest.TestCase):
     def test_latest_block_reasonable(self):
-        self.assertGreater(OrderbookFetcher.get_latest_block(), 16020300)
+        self.assertGreater(OrderbookFetcher.get_latest_block(), 19184750)
 
     def test_latest_block_increasing(self):
         latest_block = OrderbookFetcher.get_latest_block()
         self.assertGreaterEqual(OrderbookFetcher.get_latest_block(), latest_block)
 
     def test_get_order_rewards(self):
-        block_number = 17500000
-        block_range = BlockRange(block_number, block_number + 30)
+        block_number = 19184750
+        block_range = BlockRange(block_number, block_number + 25)
         rewards_df = OrderbookFetcher.get_order_rewards(block_range)
         expected = pd.DataFrame(
             {
-                "block_number": [17500006, 17500022],
+                "block_number": [
+                    19184754,
+                    19184754,
+                    19184754,
+                    19184754,
+                    19184754,
+                    19184754,
+                    19184763,
+                ],
                 "order_uid": [
-                    "0x115bb7fd4ec0c8cec1bed470b599cd187173825bfd32eec84903faf5eb7038546d335b1f889a82a6d9a7fb6db86cab15685e3c3e648dc436",
-                    "0x49f9cf94a59301548bbfaa75c06b1126cb3194d0b18a9e516ebeffabfb7e2d659cf8986e78d6215d1491c66d64409a54cf6268e4648dd550",
+                    "0x12228107308040cd64293415c7338b7ec752338aad9738deb9d10bed27cbf81558203dd7b18b262f7a422f75d79cbb230752a74e65c50d9a",
+                    "0x05c68d2a038f4feb748fbc7622a3bfb6d2484c56d616e3e3b265d4ad52d177ee40a50cf069e992aa4536211b23f286ef88752187ffffffff",
+                    "0x02bffb58877c193873693164a077c7298f470088bc517a77b6eb7d882d5d267e6ce4e9d75a1d6340812284ef564c256061cf10ba65c50cc1",
+                    "0x85d3fabb73d7029e0b3eceeeb1fe46a859a5a2aa52a482511950ba633921e63f911da057b7f735bc54e9ffbe1143dda363dba6fb65c50ce2",
+                    "0x0d44fb9adc79e104645ddcc4e04b36953e6a37a6da0c2c145350425a09ff9132851064900dcb11351e53a39e5af340e9fc2b768965c50d54",
+                    "0xa5d8c049983f2170a37180d01055b92ff67c0db2ccb9cf5d4ec7ee4c095d157f40a50cf069e992aa4536211b23f286ef88752187ffffffff",
+                    "0x95e26eba547575e86a81e6e7be87b45b56f2fd824b4bcc573bfb3f7a44b2c3c340a50cf069e992aa4536211b23f286ef88752187ffffffff",
                 ],
                 "solver": [
-                    "0x31a9ec3a6e29039c74723e387de42b79e6856fd8",
-                    "0x31a9ec3a6e29039c74723e387de42b79e6856fd8",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x6f799f4bf6c1c56fb8d890e9e0fff2934b0de157",
                 ],
-                "quote_solver": [None, None],
+                "quote_solver": [
+                    "0xc74b656bd2ebe313d26d1ac02bcf95b137d1c857",
+                    "0x16c473448e770ff647c69cbe19e28528877fba1b",
+                    None,
+                    "0xc74b656bd2ebe313d26d1ac02bcf95b137d1c857",
+                    "0x16c473448e770ff647c69cbe19e28528877fba1b",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                ],
                 "tx_hash": [
-                    "0xb3d59ac16f874a739ce93a58139ba5848d6ce521fa70fad226f3c3d2d47b2aa6",
-                    "0x22916b61ad5207a493d66b3662a27f5af1c2ac76e66672cfd9ae57041a1ca2a2",
+                    "0x43699f7356df831aa04519ecd9f638303f716ab9e41c6ab1f38aacd1c9cdd3e5",
+                    "0x43699f7356df831aa04519ecd9f638303f716ab9e41c6ab1f38aacd1c9cdd3e5",
+                    "0x43699f7356df831aa04519ecd9f638303f716ab9e41c6ab1f38aacd1c9cdd3e5",
+                    "0x43699f7356df831aa04519ecd9f638303f716ab9e41c6ab1f38aacd1c9cdd3e5",
+                    "0x43699f7356df831aa04519ecd9f638303f716ab9e41c6ab1f38aacd1c9cdd3e5",
+                    "0x43699f7356df831aa04519ecd9f638303f716ab9e41c6ab1f38aacd1c9cdd3e5",
+                    "0x321703689c7a2743c85ad91788b8ab00447de42591089d2052a3e9cf3be9d5a1",
                 ],
-                "surplus_fee": ["0", "0"],
-                "amount": [0.0, 0.0],
-                "protocol_fee": ["0", "0"],
-                "protocol_fee_token": [None, None],
-                "protocol_fee_native_price": [0.0, 0.0],
+                "surplus_fee": [
+                    "0",
+                    "0",
+                    "57709403",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                ],
+                "amount": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                ],
+                "protocol_fee": [
+                    "0",
+                    "0",
+                    "4382713635683340000",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                ],
+                "protocol_fee_token": [
+                    None,
+                    None,
+                    "0xd9fcd98c322942075a5c3860693e9f4f03aae07b",
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                "protocol_fee_native_price": [
+                    0.0,
+                    0.0,
+                    0.001552064411669457,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                ],
             }
         )
 
         self.assertIsNone(pd.testing.assert_frame_equal(expected, rewards_df))
 
     def test_get_batch_rewards(self):
-        block_number = 16846500
+        block_number = 19184750
         block_range = BlockRange(block_number, block_number + 25)
         rewards_df = OrderbookFetcher.get_batch_rewards(block_range)
         expected = pd.DataFrame(
             {
-                "block_number": pd.Series([16846495, 16846502, pd.NA], dtype="Int64"),
-                "block_deadline": [16846509, 16846516, 16846524],
+                "block_number": pd.Series(
+                    [pd.NA, 19184745, 19184748, pd.NA, 19184754, 19184763],
+                    dtype="Int64",
+                ),
+                "block_deadline": [
+                    19184752,
+                    19184754,
+                    19184757,
+                    19184760,
+                    19184763,
+                    19184771,
+                ],
                 "tx_hash": [
-                    "0x2189c2994dcffcd40cc92245e216b0fda42e0f30573ce4b131341e8ac776ed75",
-                    "0x8328fa642f47adb61f751363cf718d707dafcdc258898fa953945afd42aa020f",
                     None,
+                    "0xe4d32e53b60e830866c1cfdf101c60e61401078f7abdc30d50b442d131aa7bdc",
+                    "0x49a757b3672f25edf2e2df52c9a466c4676e72e3c4c30ac385e065366629c56f",
+                    None,
+                    "0x43699f7356df831aa04519ecd9f638303f716ab9e41c6ab1f38aacd1c9cdd3e5",
+                    "0x321703689c7a2743c85ad91788b8ab00447de42591089d2052a3e9cf3be9d5a1",
                 ],
                 "solver": [
-                    "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
-                    "0x55a37a2e5e5973510ac9d9c723aec213fa161919",
-                    "0x55a37a2e5e5973510ac9d9c723aec213fa161919",
+                    "0xc74b656bd2ebe313d26d1ac02bcf95b137d1c857",
+                    "0x047a2fbe8aef590d4eb8942426a24970af301875",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                    "0x6f799f4bf6c1c56fb8d890e9e0fff2934b0de157",
                 ],
                 "execution_cost": [
-                    "5417013431615490",
-                    "14681404168612460",
                     "0",
+                    "23960377182307338",
+                    "40296202766873088",
+                    "0",
+                    "163520173310226150",
+                    "41362753732496120",
                 ],
                 "surplus": [
-                    "5867838023808109",
-                    "104011002982952097",
                     "0",
+                    "330605523790093503",
+                    "14240247437360446",
+                    "0",
+                    "90713565103966099",
+                    "1392789908325076129",
                 ],
                 "protocol_fee": [
                     "0",
                     "0",
                     "0",
-                ],
-                "network_fee": [
-                    "7751978767036064",
-                    "10350680045815651",
+                    "0",
+                    "6802253860482580",
                     "0",
                 ],
+                "network_fee": [
+                    "0",
+                    "13933525536949544",
+                    "24543931321337540",
+                    "0",
+                    "123496472802428029",
+                    "25234871513629600",
+                ],
                 "uncapped_payment_eth": [
-                    "7232682540629268",
-                    "82825156151734420",
-                    "-3527106002507021",
+                    "-779040158516046364",
+                    "336110126639916826",
+                    "38784178758697986",
+                    "-30158667552343962",
+                    "195046679035667621",
+                    "49058033529596541",
                 ],
                 "capped_payment": [
-                    "7232682540629268",
-                    "24681404168612460",
-                    "-3527106002507021",
+                    "-10000000000000000",
+                    "35960377182307338",
+                    "38784178758697986",
+                    "-10000000000000000",
+                    "175520173310226150",
+                    "49058033529596541",
                 ],
                 "winning_score": [
-                    "6537976145828389",
-                    "95640781782532198",
-                    "3527282436747751",
+                    "781981474524515321",
+                    "322695871042736445",
+                    "2619667276946392",
+                    "46231730550348480",
+                    "50580401693171328",
+                    "1373632036694856921",
                 ],
                 "reference_score": [
-                    "6387134250214905",
-                    "31536526877033328",
-                    "3527106002507021",
+                    "779040158516046364",
+                    "8428922687126221",
+                    "0",
+                    "30158667552343962",
+                    "25965612731209087",
+                    "1368966746309109188",
                 ],
                 "participating_solvers": [
                     [
-                        "0x398890be7c4fac5d766e1aeffde44b2ee99f38ef",
-                        "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
+                        "0xc74b656bd2ebe313d26d1ac02bcf95b137d1c857",
+                        "0xdd2e786980cd58acc5f64807b354c981f4094936",
                     ],
                     [
-                        "0x55a37a2e5e5973510ac9d9c723aec213fa161919",
-                        "0x97ec0a17432d71a3234ef7173c6b48a2c0940896",
-                        "0xa21740833858985e4d801533a808786d3647fb83",
-                        "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
-                        "0xbff9a1b539516f9e20c7b621163e676949959a66",
-                        "0xc9ec550bea1c64d779124b23a26292cc223327b6",
-                        "0xda869be4adea17ad39e1dfece1bc92c02491504f",
+                        "0x047a2fbe8aef590d4eb8942426a24970af301875",
+                        "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                        "0xc74b656bd2ebe313d26d1ac02bcf95b137d1c857",
+                    ],
+                    ["0x4339889fd9dfca20a423fba011e9dff1c856caeb"],
+                    [
+                        "0x047a2fbe8aef590d4eb8942426a24970af301875",
+                        "0x0ddcb0769a3591230caa80f85469240b71442089",
+                        "0x16c473448e770ff647c69cbe19e28528877fba1b",
+                        "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                        "0x6f799f4bf6c1c56fb8d890e9e0fff2934b0de157",
+                        "0xbf54079c9bc879ae4dd6bc79bce11d3988fd9c2b",
+                        "0xc74b656bd2ebe313d26d1ac02bcf95b137d1c857",
                     ],
                     [
-                        "0x149d0f9282333681ee41d30589824b2798e9fb47",
-                        "0x3cee8c7d9b5c8f225a8c36e7d3514e1860309651",
-                        "0x55a37a2e5e5973510ac9d9c723aec213fa161919",
-                        "0x7a0a8890d71a4834285efdc1d18bb3828e765c6a",
-                        "0x97ec0a17432d71a3234ef7173c6b48a2c0940896",
-                        "0xa21740833858985e4d801533a808786d3647fb83",
-                        "0xb20b86c4e6deeb432a22d773a221898bbbd03036",
-                        "0xbff9a1b539516f9e20c7b621163e676949959a66",
-                        "0xc9ec550bea1c64d779124b23a26292cc223327b6",
-                        "0xda869be4adea17ad39e1dfece1bc92c02491504f",
-                        "0xe9ae2d792f981c53ea7f6493a17abf5b2a45a86b",
+                        "0x047a2fbe8aef590d4eb8942426a24970af301875",
+                        "0x16c473448e770ff647c69cbe19e28528877fba1b",
+                        "0x4339889fd9dfca20a423fba011e9dff1c856caeb",
+                        "0x6f799f4bf6c1c56fb8d890e9e0fff2934b0de157",
+                        "0xbf54079c9bc879ae4dd6bc79bce11d3988fd9c2b",
+                        "0xc74b656bd2ebe313d26d1ac02bcf95b137d1c857",
+                        "0xc9f2e6ea1637e499406986ac50ddc92401ce1f58",
                     ],
-                ],
-            },
-        )
-        self.assertIsNone(pd.testing.assert_frame_equal(expected, rewards_df))
-
-    def test_get_batch_rewards_with_protocol_fees(self):
-        block_number = 19034333
-        block_range = BlockRange(block_number, block_number + 9)
-        rewards_df = OrderbookFetcher.get_batch_rewards(block_range)
-        print(rewards_df)
-        expected = pd.DataFrame(
-            {
-                "block_number": pd.Series([19034331, 19034333], dtype="Int64"),
-                "block_deadline": [19034340, 19034341],
-                "tx_hash": [
-                    "0x60cfcecab62c2fc03596be4e9a9c7c1113d41a10eb9f821da04b096aacb7e73d",
-                    "0xc725ce0a051955d5c6c98e039cb52a72f96b56b5ea3e95b23ff92c746c0ae4c3",
-                ],
-                "solver": [
-                    "0x8616dcdfcecbde13ccd89eac358dc5abda79ec31",
-                    "0x01246d541e732d7f15d164331711edff217e4665",
-                ],
-                "execution_cost": [
-                    "6874093717444341",
-                    "3885032282790366",
-                ],
-                "surplus": [
-                    "1917140833491803",
-                    "45868496778113149",
-                ],
-                "protocol_fee": [
-                    "0",
-                    "463318149273870",
-                ],
-                "network_fee": [
-                    "5746294767802878",
-                    "6412406319694589",
-                ],
-                "uncapped_payment_eth": [
-                    "7613796432942231",
-                    "52744221247081608",
-                ],
-                "capped_payment": [
-                    "7613796432942231",
-                    "13885032282790366",
-                ],
-                "winning_score": [
-                    "280137833843581",
-                    "47509854752448587",
-                ],
-                "reference_score": [
-                    "49639168352450",
-                    "0",
-                ],
-                "participating_solvers": [
                     [
-                        "0x01246d541e732d7f15d164331711edff217e4665",
-                        "0x2456a4c1241e43e11b0b8f80e31c940bebd9090f",
-                        "0x8616dcdfcecbde13ccd89eac358dc5abda79ec31",
+                        "0x047a2fbe8aef590d4eb8942426a24970af301875",
+                        "0x0ddcb0769a3591230caa80f85469240b71442089",
+                        "0x16c473448e770ff647c69cbe19e28528877fba1b",
+                        "0x6f799f4bf6c1c56fb8d890e9e0fff2934b0de157",
+                        "0xc74b656bd2ebe313d26d1ac02bcf95b137d1c857",
+                        "0xd50ecb485dcf5d97266122dfed979587dd8923ac",
                     ],
-                    ["0x01246d541e732d7f15d164331711edff217e4665"],
                 ],
             },
         )


### PR DESCRIPTION
This PR implements changes due to CIP-36. See https://github.com/cowprotocol/solver-rewards/pull/339 for more details.

Fewer changes are required in this repository compared to the solver-rewards repo since some of the reward logic is implemented on dune. The respective dune queries have to be adapted as well.

After merging this a resync for the accounting period starting on 06.02.2024 is required.