### PR TITLE
Add looser block deadline in order rewards query

### DIFF
--- a/src/sql/orderbook/barn_order_rewards.sql
+++ b/src/sql/orderbook/barn_order_rewards.sql
@@ -72,7 +72,7 @@ order_surplus AS (
         ON o.uid = oq.order_uid
     WHERE
         ss.block_deadline >= {{start_block}}
-        AND ss.block_deadline <= {{end_block}}
+        AND ss.block_deadline <= {{end_block}} + 100
 ),
 order_protocol_fee AS (
     SELECT

--- a/src/sql/orderbook/barn_order_rewards.sql
+++ b/src/sql/orderbook/barn_order_rewards.sql
@@ -72,6 +72,8 @@ order_surplus AS (
         ON o.uid = oq.order_uid
     WHERE
         ss.block_deadline >= {{start_block}}
+        -- since this table filtered on block_deadline is joined with another table filtered on block_number
+        -- the bound for this table need to be a bit looser.
         AND ss.block_deadline <= {{end_block}} + 100
 ),
 order_protocol_fee AS (

--- a/src/sql/orderbook/prod_order_rewards.sql
+++ b/src/sql/orderbook/prod_order_rewards.sql
@@ -72,7 +72,7 @@ order_surplus AS (
         ON o.uid = oq.order_uid
     WHERE
         ss.block_deadline >= {{start_block}}
-        AND ss.block_deadline <= {{end_block}}
+        AND ss.block_deadline <= {{end_block}} + 100
 ),
 order_protocol_fee AS (
     SELECT


### PR DESCRIPTION
I am tempted to say that there is a bug in the order rewards query. Specifically, it seems that the following case might happen:
- we look at all trades executed between a `start_block` and an `end_block` in the trade_hashes table.
- we then pull additional information about these trades, in order to compute protocol fees etc, and these computations start with the `order_surplus` table. But in that table, which contains information from the `settlement_scores` table, we ask that the deadline of the settlements we look into is `end_block`. I think this can cause some information to be lost, because we do a left outer join of the trade_hashes table with everything else, so every trade executed between `start_block` and `end_block` will be included in our result, while not all information about these trades will have been recovered, due to the restricted `block_deadline`. This is because a trade can execute at block `x`, while its deadline might be up to `x+9`, i believe.

To address this, we propose to add some very generous buffer in the block_deadline considered, so as to ensure all relevant info about the trades are pulled together and joined in the final table.

Note: this was first noticed when i was trying to fix the integration test for PR #94 , and because of that, I opened issue #95. This PR addresses this issue.

As a final comment, an alternative would be to actually not do the above and try to only use block_deadline, similar to the batch rewards query.