### PR TITLE
add back internal imbalance table to enum

### DIFF
--- a/src/models/tables.py
+++ b/src/models/tables.py
@@ -8,6 +8,7 @@ class SyncTable(Enum):
     APP_DATA = "app_data"
     ORDER_REWARDS = "order_rewards"
     BATCH_REWARDS = "batch_rewards"
+    INTERNAL_IMBALANCE = "internal_imbalance"
 
     def __str__(self) -> str:
         return str(self.value)


### PR DESCRIPTION
After PR #87, [this line](https://github.com/cowprotocol/dune-sync/blob/47d19c18018fb324b1ed32646d0748875258ad83/src/post/aws.py#L83) has been generating tons of unnecessary logs (see [here](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(log),filters:!(),index:c0e240e0-d9b3-11ed-b0e6-e361adffce0b,interval:auto,query:(language:kuery,query:'%22Found%20unexpected%20file%22'),sort:!(!('@timestamp',desc))))), and we hadn't really paid attention to it. This PR addresses this.