### PR TITLE
[Trivial] DevContainer improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,25 @@
 		"context": "..",
 		"dockerfile": "../Dockerfile"
 	},
+  "postCreateCommand": "pip install -r requirements/dev.txt",
 	"mounts": [
 		"source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
-	]
+	],
+  "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python"
+            ],
+            "settings": {
+                "python.testing.pytestArgs": [
+                    "."
+                ],
+                "python.testing.unittestEnabled": false,
+                "python.testing.pytestEnabled": true,
+                "python.formatting.provider": "black",
+                "python.linting.mypyEnabled": true,
+                "python.linting.enabled": true
+            }
+        }
+    }
 }


### PR DESCRIPTION
I was a bit hasty merging #100. In order to properly develop using this container, we need 2 more things

1. Install python tooling inside the devcontainer's vscode
2. Install develeopment requirements (the docker container installs prod requirements only) in order to run tests/lints etc