### PR TITLE
[Trivial] remove optional env vars from critical path

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -47,9 +47,7 @@ class ScriptArgs:
 
 if __name__ == "__main__":
     load_dotenv()
-    volume_path = Path(os.environ["VOLUME_PATH"])
     args = ScriptArgs()
-    aws = AWSClient.new_from_environment()
     dune = DuneClient(os.environ["DUNE_API_KEY"])
     orderbook = OrderbookFetcher()
 
@@ -65,6 +63,8 @@ if __name__ == "__main__":
             )
         )
     elif args.sync_table == SyncTable.ORDER_REWARDS:
+        aws = AWSClient.new_from_environment()
+        volume_path = Path(os.environ["VOLUME_PATH"])
         sync_order_rewards(
             aws,
             config=SyncConfig(volume_path),
@@ -72,6 +72,8 @@ if __name__ == "__main__":
             dry_run=args.dry_run,
         )
     elif args.sync_table == SyncTable.BATCH_REWARDS:
+        aws = AWSClient.new_from_environment()
+        volume_path = Path(os.environ["VOLUME_PATH"])
         sync_batch_rewards(
             aws,
             config=SyncConfig(volume_path),


### PR DESCRIPTION
VOLUME_PATH and AWS env vars aren't needed anymore for the app_data job and so they shouldn't be required in the environment (cf. https://github.com/cowprotocol/infrastructure/pull/1770/files#diff-6ed79a81a644cd7d10f8cdd1395db1c2371d171337c95f5699db5c906a0b8682R44-R48)

### Test Plan
Run `python3 -m src.main --sync-table app_data` without any of the unrelated env vars defined.