### PR TITLE
Fix for week where Copium Capital used the same account for both staging and prod

### DIFF
--- a/src/sql/orderbook/barn_batch_rewards.sql
+++ b/src/sql/orderbook/barn_batch_rewards.sql
@@ -417,7 +417,10 @@ SELECT
         when tx_hash is NULL then NULL
         else concat('0x', encode(tx_hash, 'hex'))
     end as tx_hash,
-    concat('0x', encode(solver, 'hex')) as solver,
+    CASE
+        WHEN solver = '\x008300082C3000009e63680088f8c7f4D3ff2E87' THEN concat('0x', encode('\x8E8C00aD7011AabEa0E06e984cfA7194CF8b16b0', 'hex')) -- workaround for week where Copium used a single account for testing colocation in staging and then used the same account for prod
+        ELSE concat('0x', encode(solver, 'hex'))
+    END as solver,
     execution_cost :: text as execution_cost,
     surplus :: text as surplus,
     protocol_fee :: text as protocol_fee,

--- a/src/sql/orderbook/barn_order_rewards.sql
+++ b/src/sql/orderbook/barn_order_rewards.sql
@@ -323,8 +323,11 @@ order_protocol_fee_prices AS (
 ),
 winning_quotes as (
     SELECT
-        concat('0x', encode(oq.solver, 'hex')) as quote_solver,
-        oq.order_uid
+    CASE
+        WHEN solver = '\x008300082C3000009e63680088f8c7f4D3ff2E87' THEN concat('0x', encode('\x8E8C00aD7011AabEa0E06e984cfA7194CF8b16b0', 'hex')) -- workaround for week where Copium used a single account for testing colocation in staging and then used the same account for prod
+        ELSE concat('0x', encode(solver, 'hex'))
+    END as quote_solver,
+    oq.order_uid
     FROM
         trades t
         INNER JOIN orders o ON order_uid = uid
@@ -351,7 +354,10 @@ winning_quotes as (
 select
     trade_hashes.block_number as block_number,
     concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
-    concat('0x', encode(trade_hashes.solver, 'hex')) as solver,
+    CASE
+        WHEN solver = '\x008300082C3000009e63680088f8c7f4D3ff2E87' THEN concat('0x', encode('\x8E8C00aD7011AabEa0E06e984cfA7194CF8b16b0', 'hex')) -- workaround for week where Copium used a single account for testing colocation in staging and then used the same account for prod
+        ELSE concat('0x', encode(solver, 'hex'))
+    END as solver,
     quote_solver,
     concat('0x', encode(trade_hashes.tx_hash, 'hex')) as tx_hash,
     coalesce(surplus_fee, 0) :: text as surplus_fee,

--- a/src/sql/orderbook/barn_order_rewards.sql
+++ b/src/sql/orderbook/barn_order_rewards.sql
@@ -355,8 +355,8 @@ select
     trade_hashes.block_number as block_number,
     concat('0x', encode(trade_hashes.order_uid, 'hex')) as order_uid,
     CASE
-        WHEN solver = '\x008300082C3000009e63680088f8c7f4D3ff2E87' THEN concat('0x', encode('\x8E8C00aD7011AabEa0E06e984cfA7194CF8b16b0', 'hex')) -- workaround for week where Copium used a single account for testing colocation in staging and then used the same account for prod
-        ELSE concat('0x', encode(solver, 'hex'))
+        WHEN trade_hashes.solver = '\x008300082C3000009e63680088f8c7f4D3ff2E87' THEN concat('0x', encode('\x8E8C00aD7011AabEa0E06e984cfA7194CF8b16b0', 'hex')) -- workaround for week where Copium used a single account for testing colocation in staging and then used the same account for prod
+        ELSE concat('0x', encode(trade_hashes.solver, 'hex'))
     END as solver,
     quote_solver,
     concat('0x', encode(trade_hashes.tx_hash, 'hex')) as tx_hash,


### PR DESCRIPTION
The script currently produces an error if the same address was used both for staging and prod submissions. This was indeed the case for Copium Capital that tested colocation in staging before we enabled them with the same account in prod (and disabled them in staging at the same time).

The proposed solution is really to bypass the check just for this one occasion, by pretending that the staging submissions of Copium Capital didn't happen from address `0x008300082C3000009e63680088f8c7f4D3ff2E87`,  but instead from the old staging address that the core team controls.