### PR TITLE
Remove assert for solver overlap

### DIFF
--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -12,8 +12,11 @@ from pandas import DataFrame
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
+from src.logger import set_log
 from src.models.block_range import BlockRange
 from src.utils import open_query
+
+log = set_log(__name__)
 
 MAX_PROCESSING_DELAY = 10
 
@@ -96,7 +99,12 @@ class OrderbookFetcher:
         )
 
         # Solvers do not appear in both environments!
-        assert set(prod.solver).isdisjoint(set(barn.solver)), "solver overlap!"
+        if set(prod.solver).isdisjoint(set(barn.solver)):
+            log.warning(
+                f"solver overlap in {block_range}: solvers "
+                f"{set(prod.solver).intersection(set(barn.solver))} part of both prod and barn"
+            )
+
         if not prod.empty and not barn.empty:
             return pd.concat([prod, barn])
         if not prod.empty:
@@ -143,7 +151,14 @@ class OrderbookFetcher:
         )
 
         # Solvers do not appear in both environments!
-        assert set(prod.solver).isdisjoint(set(barn.solver)), "solver overlap!"
+        if set(prod.solver).isdisjoint(set(barn.solver)):
+            log.warning(
+                f"solver overlap in {block_range}: solvers "
+                f"{set(prod.solver).intersection(set(barn.solver))} part of both prod and barn"
+            )
+
+        return pd.concat([prod, barn])
+
         if not prod.empty and not barn.empty:
             return pd.concat([prod, barn])
         if not prod.empty:


### PR DESCRIPTION
This PR removes an assert which checked that solvers do only appear in one of prod and barn. Instead, a warning is logged.

Even though in most cases a solver appearing in prod and barn is a sign of invalid solver behavior, the rest of the code of this repo does not depend on this assumption. Data is just concatenated and uploaded as is.

The [main rewards query](https://github.com/cowprotocol/dune-queries/blob/main/cowprotocol/accounting/rewards/mainnet/mainnet_dashboard_query_2510345.sql) on dune also does not depend on associating settlements to environments. The environment is only added after aggregating payments [here](https://github.com/cowprotocol/dune-queries/blob/6be6c1cfaa78b3dfc2ed65494c2cc0ef5c303889/cowprotocol/accounting/rewards/mainnet/mainnet_dashboard_query_2510345.sql#L118) for easier digestion of the final table.