### PR TITLE
Remove prefect from deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,11 +37,5 @@ jobs:
         with:
           python-version: '3.12'
 
-      - env:
-          PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
       - run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/prefect.txt
-          pip install -r requirements/prod.txt
-          prefect config set PREFECT_API_URL=$PREFECT_API_URL
-          python -m src.deploy_prefect.deployment

--- a/src/models/batch_rewards_schema.py
+++ b/src/models/batch_rewards_schema.py
@@ -35,7 +35,6 @@ class BatchRewards:
                     "fee": int(row["network_fee"]),
                     "winning_score": int(row["winning_score"]),
                     "reference_score": int(row["reference_score"]),
-                    "participating_solvers": row["participating_solvers"],
                 },
             }
             for row in rewards_df.to_dict(orient="records")

--- a/tests/unit/test_batch_rewards_schema.py
+++ b/tests/unit/test_batch_rewards_schema.py
@@ -34,21 +34,6 @@ class TestModelBatchRewards(unittest.TestCase):
                 "capped_payment": [-1000000000000000, -1000000000000000],
                 "winning_score": [123456 * ONE_ETH, 6789 * ONE_ETH],
                 "reference_score": [ONE_ETH, 2 * ONE_ETH],
-                "participating_solvers": [
-                    [
-                        "0x51",
-                        "0x52",
-                        "0x53",
-                    ],
-                    [
-                        "0x51",
-                        "0x52",
-                        "0x53",
-                        "0x54",
-                        "0x55",
-                        "0x56",
-                    ],
-                ],
             }
         )
 
@@ -61,7 +46,6 @@ class TestModelBatchRewards(unittest.TestCase):
                         "capped_payment": -1000000000000000,
                         "execution_cost": 9999000000000000000000,
                         "fee": 1000000000000000,
-                        "participating_solvers": ["0x51", "0x52", "0x53"],
                         "protocol_fee": 2000000000000000,
                         "reference_score": 1000000000000000000,
                         "surplus": 2000000000000000000,
@@ -78,14 +62,6 @@ class TestModelBatchRewards(unittest.TestCase):
                         "capped_payment": -1000000000000000,
                         "execution_cost": 1,
                         "fee": max_uint,
-                        "participating_solvers": [
-                            "0x51",
-                            "0x52",
-                            "0x53",
-                            "0x54",
-                            "0x55",
-                            "0x56",
-                        ],
                         "protocol_fee": 0,
                         "reference_score": 2000000000000000000,
                         "surplus": 3000000000000000000,


### PR DESCRIPTION
I believe the deployment is a bit messed up, as we currently have dune-sync only deployed in prod while prefect lives in staging. The plan is to migrate everything to staging, but until then, any new release issued in prod cannot work; i see these errors
`
stream logs failed container "batch-rewards" in pod "dune-sync-mainnet-batch-rewards-cj-..." is waiting to start: trying and failing to pull image for analytics/dune-sync-mainnet-batch-rewards-cj-...(batch-rewards) `

and i believe the reason is prefect. This PR removes the prefect deployment until we sort things out.

UPDATE: PR was applied and it worked but the latest run revealed another bug; PR #114 had not done a proper cleanup of the references to participation. Given it's a Saturday night and the script is still crashing, i decided to push the fix for that bug in this PR, which basically now serves as the working version of what I am tempting to deploy. We can discuss how to proceed with these on Monday