### PR TITLE
Sync price feed

### DIFF
--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -28,6 +28,7 @@ class OrderbookEnv(Enum):
 
     BARN = "BARN"
     PROD = "PROD"
+    ANALYTICS = "ANALYTICS"
 
     def __str__(self) -> str:
         return str(self.value)
@@ -175,3 +176,11 @@ class OrderbookFetcher:
 
         # We are only interested in unique app data
         return pd.concat([prod, barn]).drop_duplicates().reset_index(drop=True)
+
+    @classmethod
+    def get_price_feed(cls) -> DataFrame:
+        """
+        Fetches prices from multiple price feeds from the analytics db
+        """
+        prices_query = open_query("prices.sql")
+        return cls._read_query_for_env(prices_query, OrderbookEnv.ANALYTICS)

--- a/src/main.py
+++ b/src/main.py
@@ -49,7 +49,10 @@ class ScriptArgs:
 if __name__ == "__main__":
     load_dotenv()
     args = ScriptArgs()
-    dune = DuneClient(os.environ["DUNE_API_KEY"])
+    dune = DuneClient(
+        api_key=os.environ["DUNE_API_KEY"],
+        request_timeout=float(os.environ.get("DUNE_API_REQUEST_TIMEOUT", 10)),
+    )
     orderbook = OrderbookFetcher()
 
     if args.sync_table == SyncTable.APP_DATA:

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,8 @@ from src.logger import set_log
 from src.models.tables import SyncTable
 from src.post.aws import AWSClient
 from src.sync import sync_app_data
-from src.sync.config import SyncConfig, AppDataSyncConfig
+from src.sync import sync_price_feed
+from src.sync.config import SyncConfig, AppDataSyncConfig, PriceFeedSyncConfig
 from src.sync.order_rewards import sync_order_rewards, sync_batch_rewards
 
 log = set_log(__name__)
@@ -59,6 +60,17 @@ if __name__ == "__main__":
                 orderbook,
                 dune=dune,
                 config=AppDataSyncConfig(table),
+                dry_run=args.dry_run,
+            )
+        )
+    elif args.sync_table == SyncTable.PRICE_FEED:
+        table = os.environ["PRICE_FEED_TARGET_TABLE"]
+        assert table, "PRICE FEED sync needs a PRICE_FEED_TARGET_TABLE env"
+        asyncio.run(
+            sync_price_feed(
+                orderbook,
+                dune=dune,
+                config=PriceFeedSyncConfig(table),
                 dry_run=args.dry_run,
             )
         )

--- a/src/models/tables.py
+++ b/src/models/tables.py
@@ -9,6 +9,7 @@ class SyncTable(Enum):
     ORDER_REWARDS = "order_rewards"
     BATCH_REWARDS = "batch_rewards"
     INTERNAL_IMBALANCE = "internal_imbalance"
+    PRICE_FEED = "price_feed"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/src/sql/prices.sql
+++ b/src/sql/prices.sql
@@ -1,5 +1,4 @@
--- Selects all known appData hashes and preimages (as string) from the backend database
-
+-- Selects all prices collected in the analytics db
 SELECT 
   concat('0x', encode(token_address, 'hex')) as token_address,
   time,

--- a/src/sql/prices.sql
+++ b/src/sql/prices.sql
@@ -1,5 +1,8 @@
 -- Selects all known appData hashes and preimages (as string) from the backend database
 
 SELECT 
-  *
+  concat('0x', encode(token_address, 'hex')) as token_address,
+  time,
+  price,
+  source
 FROM prices

--- a/src/sql/prices.sql
+++ b/src/sql/prices.sql
@@ -1,7 +1,8 @@
 -- Selects all prices collected in the analytics db
 SELECT 
-  concat('0x', encode(token_address, 'hex')) as token_address,
-  time,
-  price,
-  source
-FROM prices
+  concat('0x', encode(p.token_address, 'hex')) as token_address,
+  p.time,
+  p.price,
+  td.decimals,
+  p.source
+FROM prices p INNER JOIN token_decimals td ON p.token_address = td.token_address

--- a/src/sql/prices.sql
+++ b/src/sql/prices.sql
@@ -1,0 +1,5 @@
+-- Selects all known appData hashes and preimages (as string) from the backend database
+
+SELECT 
+  *
+FROM prices

--- a/src/sync/__init__.py
+++ b/src/sync/__init__.py
@@ -1,2 +1,3 @@
 """Re-exported sync methods."""
 from .app_data import sync_app_data
+from .price_feed import sync_price_feed

--- a/src/sync/config.py
+++ b/src/sync/config.py
@@ -37,4 +37,4 @@ class PriceFeedSyncConfig:
     # The name of the table to upload to
     table: str = "price_feed_test"
     # Description of the table (for creation)
-    description: str = "Table containing prices and timestamps from multiple prices relevant to imbalances occuring after each tx."
+    description: str = "Table containing prices and timestamps from multiple price feeds"

--- a/src/sync/config.py
+++ b/src/sync/config.py
@@ -28,3 +28,13 @@ class AppDataSyncConfig:
     description: str = (
         "Table containing known CoW Protocol appData hashes and their pre-images"
     )
+
+
+@dataclass
+class PriceFeedSyncConfig:
+    """Configuration for price feed sync."""
+
+    # The name of the table to upload to
+    table: str = "price_feed_test"
+    # Description of the table (for creation)
+    description: str = "Table containing prices and timestamps from multiple prices relevant to imbalances occuring after each tx."

--- a/src/sync/config.py
+++ b/src/sync/config.py
@@ -37,4 +37,6 @@ class PriceFeedSyncConfig:
     # The name of the table to upload to
     table: str = "price_feed_test"
     # Description of the table (for creation)
-    description: str = "Table containing prices and timestamps from multiple price feeds"
+    description: str = (
+        "Table containing prices and timestamps from multiple price feeds"
+    )

--- a/src/sync/price_feed.py
+++ b/src/sync/price_feed.py
@@ -1,4 +1,4 @@
-"""Main Entry point for app_hash sync"""
+"""Main Entry point for price feed sync"""
 
 from dune_client.client import DuneClient
 

--- a/src/sync/price_feed.py
+++ b/src/sync/price_feed.py
@@ -1,0 +1,27 @@
+"""Main Entry point for app_hash sync"""
+
+from dune_client.client import DuneClient
+
+from src.fetch.orderbook import OrderbookFetcher
+from src.logger import set_log
+from src.sync.config import PriceFeedSyncConfig
+
+log = set_log(__name__)
+
+
+async def sync_price_feed(
+    orderbook: OrderbookFetcher,
+    dune: DuneClient,
+    config: PriceFeedSyncConfig,
+    dry_run: bool,
+) -> None:
+    """Price Feed Sync Logic"""
+    prices = orderbook.get_price_feed()
+    if not dry_run:
+        dune.upload_csv(
+            data=prices.to_csv(index=False),
+            table_name=config.table,
+            description=config.description,
+            is_private=False,
+        )
+    log.info("price feed sync run completed successfully")


### PR DESCRIPTION
This PR adds a simple job that pushes all prices collected in the `prices` table of the analytics db to Dune. It mimics PR #103, and is meant to run as a cronjob. I followed the "legacy method" as there are some concerns about the current way Prefect has been integrated in this repo.

I also prepared this PR in the infra repo. https://github.com/cowprotocol/infrastructure/pull/2217

Note: there are currently not any tests. I saw there are some tests for the app-data sync, so i could try to basically copy-paste those, as i am not sure what's the best way to test this

