### PR TITLE
Add setup for pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(name='dune-sync',
+      version='0.1',
+      description='Components for syncing off-chain data with Dune Community Sources ',
+      url='https://github.com/cowprotocol/dune-sync',
+      author='cowprotocol',
+      author_email='info@cow.fi',
+      packages=['src'],
+      zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,12 @@
 from setuptools import setup
 
-setup(name='dune-sync',
-      version='0.1',
-      description='Components for syncing off-chain data with Dune Community Sources ',
-      url='https://github.com/cowprotocol/dune-sync',
-      author='cowprotocol',
-      author_email='info@cow.fi',
-      packages=['src'],
-      zip_safe=False)
+setup(
+    name="dune-sync",
+    version="0.1",
+    description="Components for syncing off-chain data with Dune Community Sources ",
+    url="https://github.com/cowprotocol/dune-sync",
+    author="cowprotocol",
+    author_email="info@cow.fi",
+    packages=["src"],
+    zip_safe=False,
+)


### PR DESCRIPTION
This PR adds a setup.py file so that the dune-sync repo can be installed with pip using `pip install git+https://github.com/cowprotocol/dune-sync.git@<branch-name>`.