### PR TITLE
Update sqlalchemy to 2.0 and update setup.py

### DIFF
--- a/manifest.in
+++ b/manifest.in
@@ -1,2 +1,3 @@
 include logging.conf
 include requirements/prod.txt
+include src/sql/**/*.sql

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -6,4 +6,4 @@ pandas==2.1.4
 ndjson>=0.3.1
 py-multiformats-cid>=0.4.4
 boto3>=1.26.12
-SQLAlchemy<2.0
+SQLAlchemy<3.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -6,4 +6,4 @@ pandas==2.1.4
 ndjson>=0.3.1
 py-multiformats-cid>=0.4.4
 boto3>=1.26.12
-SQLAlchemy<3.0
+SQLAlchemy>=2.0,<3.0

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,11 @@ from setuptools import setup, find_packages
 subpackages = find_packages("src")
 packages = ["src"] + ["src." + p for p in subpackages]
 
+
 def read_requirements(filename):
     with open(filename, "r") as f:
         return [line.strip() for line in f.readlines() if line.strip()]
+
 
 def get_sql_files(directory):
     sql_files = []
@@ -14,7 +16,11 @@ def get_sql_files(directory):
         for file in files:
             if file.endswith(".sql"):
                 # Add 'src/' prefix to the path
-                sql_files.append(os.path.join('src', os.path.relpath(os.path.join(root, file), start="src")))
+                sql_files.append(
+                    os.path.join(
+                        "src", os.path.relpath(os.path.join(root, file), start="src")
+                    )
+                )
     return sql_files
 
 
@@ -33,7 +39,11 @@ setup(
         ),
         (
             os.path.join(
-                "lib", "python{0}.{1}".format(*os.sys.version_info[:2]), "site-packages", "src", "sql"
+                "lib",
+                "python{0}.{1}".format(*os.sys.version_info[:2]),
+                "site-packages",
+                "src",
+                "sql",
             ),
             get_sql_files("src/sql"),
         ),

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,18 @@ from setuptools import setup, find_packages
 subpackages = find_packages("src")
 packages = ["src"] + ["src." + p for p in subpackages]
 
-
 def read_requirements(filename):
     with open(filename, "r") as f:
         return [line.strip() for line in f.readlines() if line.strip()]
+
+def get_sql_files(directory):
+    sql_files = []
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".sql"):
+                # Add 'src/' prefix to the path
+                sql_files.append(os.path.join('src', os.path.relpath(os.path.join(root, file), start="src")))
+    return sql_files
 
 
 setup(
@@ -22,7 +30,13 @@ setup(
                 "lib", "python{0}.{1}".format(*os.sys.version_info[:2]), "site-packages"
             ),
             ["logging.conf"],
-        )
+        ),
+        (
+            os.path.join(
+                "lib", "python{0}.{1}".format(*os.sys.version_info[:2]), "site-packages", "src", "sql"
+            ),
+            get_sql_files("src/sql"),
+        ),
     ],
     install_requires=read_requirements("requirements/prod.txt"),
 )

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -49,11 +49,19 @@ class OrderbookFetcher:
         db_string = f"postgresql+psycopg2://{db_url}"
         return create_engine(db_string)
 
+    @staticmethod
+    def _get_connection(db_env: OrderbookEnv):
+        """Returns a database connection"""
+        engine = OrderbookFetcher._pg_engine(db_env)
+        return engine.connect()
+
     @classmethod
     def _read_query_for_env(
         cls, query: str, env: OrderbookEnv, data_types: Optional[dict[str, str]] = None
     ) -> DataFrame:
-        return pd.read_sql_query(query, con=cls._pg_engine(env), dtype=data_types)
+        """Reads a query with a connection object"""
+        with cls._get_connection(env) as conn:
+            return pd.read_sql_query(query, con=conn, dtype=data_types)
 
     @classmethod
     def _query_both_dbs(
@@ -184,3 +192,4 @@ class OrderbookFetcher:
         """
         prices_query = open_query("prices.sql")
         return cls._read_query_for_env(prices_query, OrderbookEnv.ANALYTICS)
+

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -10,7 +10,7 @@ import pandas as pd
 from dotenv import load_dotenv
 from pandas import DataFrame
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Engine, Connection
 
 from src.logger import set_log
 from src.models.block_range import BlockRange
@@ -50,7 +50,7 @@ class OrderbookFetcher:
         return create_engine(db_string)
 
     @staticmethod
-    def _get_connection(db_env: OrderbookEnv):
+    def _get_connection(db_env: OrderbookEnv) -> Connection:
         """Returns a database connection"""
         engine = OrderbookFetcher._pg_engine(db_env)
         return engine.connect()

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -10,7 +10,7 @@ import pandas as pd
 from dotenv import load_dotenv
 from pandas import DataFrame
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine, Connection
+from sqlalchemy.engine import Engine
 
 from src.logger import set_log
 from src.models.block_range import BlockRange
@@ -49,19 +49,11 @@ class OrderbookFetcher:
         db_string = f"postgresql+psycopg2://{db_url}"
         return create_engine(db_string)
 
-    @staticmethod
-    def _get_connection(db_env: OrderbookEnv) -> Connection:
-        """Returns a database connection"""
-        engine = OrderbookFetcher._pg_engine(db_env)
-        return engine.connect()
-
     @classmethod
     def _read_query_for_env(
         cls, query: str, env: OrderbookEnv, data_types: Optional[dict[str, str]] = None
     ) -> DataFrame:
-        """Reads a query with a connection object"""
-        with cls._get_connection(env) as conn:
-            return pd.read_sql_query(query, con=conn, dtype=data_types)
+        return pd.read_sql_query(query, con=cls._pg_engine(env), dtype=data_types)
 
     @classmethod
     def _query_both_dbs(

--- a/src/fetch/orderbook.py
+++ b/src/fetch/orderbook.py
@@ -192,4 +192,3 @@ class OrderbookFetcher:
         """
         prices_query = open_query("prices.sql")
         return cls._read_query_for_env(prices_query, OrderbookEnv.ANALYTICS)
-


### PR DESCRIPTION
This PR updates the sqlalchemy version of the dune-sync repo to <3.0. This is needed for compatibility with Prefect. It also updates the setup.py to include the .sql files.